### PR TITLE
Fix broken links in NEWS

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -36,8 +36,8 @@ PEL -- Pragmatic Emacs Library --  NEWS         -*- org -*-
   -  the ~<f11> , p~ key sequence is bound to *completion-preview-mode*.
   -  the ~<f11> , P~ key sequence (upper-case P) is bound to *global-completion-preview-mode*.
   When the mode is active the ~M-n~ and ~M-p~ keys are active to select next and previous completion candidate.
-- Add an early version of the [[https://raw.githubusercontent.com/pierre-rouleau/pel/master/doc/pdf/pel-tcl.pdf][𝕻𝔩 - Tcl]] PDF.
-- Add preliminary support for Lua when *pel-use-lua* is set. Add an early version of the [[https://raw.githubusercontent.com/pierre-rouleau/pel/master/doc/pdf/pel-lua.pdf][𝕻𝔩 - Lua]] PDF.
+- Add an early version of the [[https://raw.githubusercontent.com/pierre-rouleau/pel/master/doc/pdf/pl-tcl.pdf][𝕻𝔩 - Tcl]] PDF.
+- Add preliminary support for Lua when *pel-use-lua* is set. Add an early version of the [[https://raw.githubusercontent.com/pierre-rouleau/pel/master/doc/pdf/pl-lua.pdf][𝕻𝔩 - Lua]] PDF.
 - The ~<f12><f12>~ key prefix holding keybindings related to tempo skeleton insertion and management is now available for the
   *sh-mode*, D, Lua, Nim, Perl, Pike, Python and Ruby, Tcl and Tcl expect buffers.
   - While doing that I also improved the *pel-tempo-install-pel-skel* function, allowing the creation of a command bound
@@ -48,13 +48,13 @@ PEL -- Pragmatic Emacs Library --  NEWS         -*- org -*-
   The command is used to interactively select a major mode for config or script modes that use a shebang line.
   Once the command is used to select the major mode, the ~<f12>~ key becomes a prefix key.
 - Add preliminary PEL support for the Pike programming language:
-  - Add the [[https://raw.githubusercontent.com/pierre-rouleau/pel/master/doc/pdf/pel-pike.pdf][𝕻𝔩 - Pike]] PDF.  It's an early version.
+  - Add the [[https://raw.githubusercontent.com/pierre-rouleau/pel/master/doc/pdf/pl-pike.pdf][𝕻𝔩 - Pike]] PDF.  It's an early version.
   - The PEL support for Pike is controlled by the *pel-use-pike* user-option: set it to t and restart Emacs to activate it.
     - For now it provides the ~<f12>~ key prefix for Pike in pike-mode buffer.
       Since pike-mode derives from cc-mode, lots of support is inherited, but not yet documented.
       Several PEL features are not yet activated for Pike.
 - Add (experimental) support for the Odin programming language:
-  - Add the [[https://raw.githubusercontent.com/pierre-rouleau/pel/master/doc/pdf/pel-odin.pdf][𝕻𝔩 - Odin]] PDF.  It's an early version.
+  - Add the [[https://raw.githubusercontent.com/pierre-rouleau/pel/master/doc/pdf/pl-odin.pdf][𝕻𝔩 - Odin]] PDF.  It's an early version.
   - The support for Odin is controlled by the *pel-use-odin* user-option: set it to t and restart Emacs to activate it.
   - Add support for *flycheck-odin* when *pel-use-flycheck-odin* user-option is set to t.
 - Supports org-mode modification in Emacs 30.1 and later: tab-width for org-mode is fixed to 8.
@@ -89,7 +89,7 @@ PEL -- Pragmatic Emacs Library --  NEWS         -*- org -*-
   whitespace when there's several lines between point and the next
   non-whitespace.  It's now also able to delete backwards when provided with a
   negative argument.
-- *pel-open-at-point* (which is bound to ~<M-<f6>~ and ~<f11> f .~) is now able to open
+- *pel-open-at-point* (which is bound to ~M-<f6>~ and ~<f11> f .~) is now able to open
   remote files or directories that are expressed with Tramp-compliant syntax.
   Note that it was and continues to be possible to use
   *pel-set-open-at-point-dir* (which is bound to ~<f11> f ;~ ) to set the
@@ -2269,7 +2269,7 @@ PEL -- Pragmatic Emacs Library --  NEWS         -*- org -*-
     - The previously used ~<f12> F~ key sequence to toggle flymake is
       replaced by ~<f12> !~ which is bound to *pel-erlang-toggle-syntax-check*.
   - New: *Forth*:
-    - New: [[https://raw.githubusercontent.com/pierre-rouleau/pel/master/doc/pdf/pl-forth][𝕻𝔩 - Forth]] PDF that describes the commands available for the Forth
+    - New: [[https://raw.githubusercontent.com/pierre-rouleau/pel/master/doc/pdf/pl-forth.pdf][𝕻𝔩 - Forth]] PDF that describes the commands available for the Forth
       programming language.
     - New: the ~<f11> x f~ key sequences opens a Forth interpreter window.
   - New: *Go*:
@@ -2280,14 +2280,14 @@ PEL -- Pragmatic Emacs Library --  NEWS         -*- org -*-
         - The *pel-use-goflymake* user-option identifies whether flymake or
           flycheck is used with Go files.  The ~<f12> !~ key can be used to
           toggle the activated mode.
-    - New: [[https://raw.githubusercontent.com/pierre-rouleau/pel/master/doc/pdf/pl-go][𝕻𝔩 - Go]] PDF that describes the commands available for the Go
+    - New: [[https://raw.githubusercontent.com/pierre-rouleau/pel/master/doc/pdf/pl-go.pdf][𝕻𝔩 - Go]] PDF that describes the commands available for the Go
      programming language.
   - New: *Gleam*, an Erlang BEAM language
     - New: added support for the Gleam programming language, activated when
       the *pel-use-gleam* user-option is turned on (set to *t*).  The support
       is very basic.  It provides early *gleam-mode* package when the
       *pel-use-gleam-mode* user-option is turned on.
-    - New:  [[https://raw.githubusercontent.com/pierre-rouleau/pel/master/doc/pdf/pl-gleam][𝕻𝔩 - Gleam]] PDF.
+    - New:  [[https://raw.githubusercontent.com/pierre-rouleau/pel/master/doc/pdf/pl-gleam.pdf][𝕻𝔩 - Gleam]] PDF.
   - New: **Haskell**
     - New: add explicit support for Haskell via the *pel-use-haskell* user-option.
       Also provide the *pel-haskell-activates-minor-modes* user-option to automatically
@@ -2552,7 +2552,7 @@ PEL -- Pragmatic Emacs Library --  NEWS         -*- org -*-
 + New: [[https://raw.githubusercontent.com/pierre-rouleau/pel/master/doc/pdf/pl-rexx.pdf][𝕻𝔩 - REXX]] PDF describing support for the REXX programming language.
 + New: [[https://raw.githubusercontent.com/pierre-rouleau/pel/master/doc/pdf/mode-markdown.pdf][Ɱ Markdown PDF]], describing markdown support.
 + New: [[https://raw.githubusercontent.com/pierre-rouleau/pel/master/doc/pdf/macOS-keys.pdf][ macOS Keys ]]PDF that lists and describes the macOS specific keys.
-+ New: [[https://raw.githubusercontent.com/pierre-rouleau/pel/master/doc/pdf/-CRiSP-Emacs.pdf][➢CRiSP ➫ Emacs] PDF for Brief and CRiSP users.  It lists the
++ New: [[https://raw.githubusercontent.com/pierre-rouleau/pel/master/doc/pdf/-CRiSP-Emacs.pdf][➢CRiSP ➫ Emacs]] PDF for Brief and CRiSP users.  It lists the
   correspondences between Brief/CRiSP with CRiSPer and Emacs with PEL.
 ** Use Manual Additions and Improvements:
 - Added instructions on how to install


### PR DESCRIPTION
Hi Pierre (@pierre-rouleau),

This PR fixes some broken links in NEWS mostly for PDF files (and one ~M change at line 92).

Some further notes:

- The https://github.com/michael-heerdegen/interaction-log.el link is broken as the repo no longer exists. Perhaps link to https://github.com/Wilfred/.emacs.d/blob/gh-pages/elpa/interaction-log-20160305.501/interaction-log.el instead?

- Your "etags-cpp" does not exist in the "[bin](https://github.com/pierre-rouleau/pel/tree/master/bin)" directory. It got removed in commit [00aff5a](https://github.com/pierre-rouleau/pel/commit/00aff5a0c552bda2078b29304f9bd0f91c154b50). Might you want to make a note that "etags-c now handles C++" in the NEWS file?

Kind Regards,
Liam