### PR TITLE
Makefile ensures that pel.el is compiled.

### DIFF
--- a/pel.el
+++ b/pel.el
@@ -5,7 +5,7 @@
 ;; Author: Pierre Rouleau <prouleau001@gmail.com>
 ;; URL: https://github.com/pierre-rouleau/pel
 ;; Version: 0.4.1
-;; Package-Requires: ((emacs "26.1") (use-package "2.4"))
+;; Package-Requires: ((emacs "26.1"))
 ;; Keywords: convenience
 
 ;; This file is not part of GNU Emacs.
@@ -66,9 +66,6 @@
 ;; are used by that.  But they can also be used independently.  So if you
 ;; do not want to use PEL key bindings, you can just use some of the PEL
 ;; modules and provide you own bindings in your own Emacs init file.
-;;
-;; This is an early version of PEL.  It will grow with time, incorporating
-;; more Emacs packages to support more editing tasks.
 ;;
 ;; To use the PEL auto-loading of packages and key bindings, put the
 ;; following code inside your Emacs init.el file:


### PR DESCRIPTION
* Some cleanup in the Makefile, declaring PHONY targets that are not file nor directory.
* Update comment in pel.el as PEL evolved with several packages.
* Cleanup: remove the use-package dependency: PEL has not been using use-package for some time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified package dependencies by removing use-package requirement.
  * Enhanced build system with new public targets and improved compilation workflow.
  * Added dedicated test and stats reporting targets.

* **Documentation**
  * Updated build system help text for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->