### PR TITLE
Report the emacs-init-time reported within Emacs.

### DIFF
--- a/bin/e-time
+++ b/bin/e-time
@@ -4,7 +4,7 @@
 # Purpose   : Time Emacs startup.
 # Created   : Monday, February 23 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-02-24 17:43:24 EST, updated by Pierre Rouleau>
+# Time-stamp: <2026-02-24 17:55:10 EST, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -78,7 +78,7 @@ print_usage()
 
   Note that the script uses the file ~/tmp/emacs-time.txt to store
   information that is later added into the report.  The script
-  stop in error if the directory does not exist or the file is present.
+  stop with  an error if the directory does not exist or the file is present.
 
 " "$pgm_name" "$pgm_name" "$pgm_name"
 }
@@ -197,7 +197,7 @@ printf -- "\nTerminal startup, using emacs-init-time:\n"           >> "$REPORT_F
 (e --batch -l ~/.emacs.d/init.el  --eval '(progn (pel-init) (message "Emacs startup time (batch mode): %s" (emacs-init-time)))') 2>&1 | grep "Emacs startup time (batch mode):" >> "$REPORT_FILE"
 (e --eval '(progn (write-region (format "Emacs startup time (user mode) : %s\n" (emacs-init-time)) nil "~/tmp/emacs-time.txt"  t) (kill-emacs))')
 cat "$HOME/tmp/emacs-time.txt" >> "$REPORT_FILE"
-rm "$HOME/tmp/emacs-time.txt"
+rm -f "$HOME/tmp/emacs-time.txt"
 
 if [ "$test_gui" = "yes" ]; then
     printf -- "\nGraphical startup: emacs -e kill-emacs :"         >> "$REPORT_FILE"


### PR DESCRIPTION
* This is done in 2 ways: in Emacs batch-mode and in user-mode. to highlight the difference in startup time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new batch-mode timing path to capture and include additional Emacs startup metrics in the generated report.

* **Documentation**
  * Expanded usage/help text with updated instructions and setup requirements for the timing flow.

* **Bug Fixes**
  * Added pre-checks and validations for required temporary storage and file state to prevent runtime errors during report generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->