### PR TITLE
Add missing pel-dart-setup-info mapped to Dart <f12> ?

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ PEL -- Pragmatic Emacs Library --  NEWS         -*- org -*-
 
 * Changes since Version 0.4.1:
 ** Modifications, Fixes and Improvements:
+- Fix Dart support for the ~<f12> ?~ key to get info on Dart major mode: completed the *pel-dart-setup-info* implementation.
 - Fix Emacs requirements for the gt package: it requires Emacs 28.1, not Emacs 27.1.
 - Add header file searching features to the Objective-C and Pike major modes similar to what PEL already supports in AWK, C and C++.
 - Improve *pel-ffind-inpath-include*: it now properly handles several errors in environment variable values:

--- a/pel-autoload.el
+++ b/pel-autoload.el
@@ -333,7 +333,8 @@ Argument FOR: just a required separator keyword to make code look better."
 
   ;; --
   (pel-autoload "pel-dart" for:
-    pel-dart-mode)
+    pel-dart-mode
+    pel-dart-setup-info)
   (pel-autoload-function "pel-dart" for:
     pel--dart-ts-mode-fixer)
 

--- a/pel-dart.el
+++ b/pel-dart.el
@@ -2,12 +2,12 @@
 
 ;; Created   : Tuesday, November  4 2025.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2025-11-05 15:32:21 EST, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-13 22:30:47 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
 
-;; Copyright (C) 2025  Pierre Rouleau
+;; Copyright (C) 2025, 2026  Pierre Rouleau
 ;;
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -27,31 +27,6 @@
 ;;
 ;; Support for the Dart programming language.
 ;;
-;; Dart takes a very strong approach to indentation, forcing indentation to be
-;; 2 spaces, always.  Their tools force this convention.  Several people
-;; complained about the lack of flexibility of this approach that causes them
-;; personal pain as well as causing problem in team environments.
-;;
-;; See:
-;;  - https://github.com/dart-lang/dart_style/issues/534
-;;  - https://github.com/dart-lang/dart_style/issues/1683
-;;
-;; IMHO, the selected approach is quite misguided and way too inflexible.
-;; Several people find it difficult to read code that has a 2 column width
-;; indentation.  Perhaps one day, several people that do not see a problem
-;; with it now will find themselves in a similar situation and will have to
-;; change their views on this.
-;;
-;; A very strict yet better and respectful approach would have been to
-;; impose a 2 column indentation with a 2-column width hard-tab with line
-;; length computing the hard-tab as a 2 column width.  That would have allowed
-;; people to increase tab width to a larger value to widen the rendering of
-;; indentation on their screen without any impact on the file's content.
-;;
-;; I will try to provide a way to deal with this limitation in Emacs, by
-;; dynamically replacing 2-space indentation with hard-tabs that can then be
-;; expanded to any width to help make it look wider.
-;;
 ;; Two modes support Dart: the classic `dart-mode' and the `dart-ts-mode'.
 ;;
 ;; * `dart-mode':
@@ -66,6 +41,45 @@
 ;;   - Indentation width is controlled by `dart-ts-mode-indent-offset'
 ;;     user-option which defaults to 2.
 ;;
+
+;; Dart takes a very strong approach to indentation, forcing indentation to be
+;; 2 spaces, always.  Dart tools force this convention.
+;;
+;; Several people complained about the lack of flexibility of this approach
+;; that causes them personal pain as well as causing problem in team
+;; environments.
+;;
+;; See:
+;;  - https://github.com/dart-lang/dart_style/issues/534
+;;  - https://github.com/dart-lang/dart_style/issues/1683
+;;
+;; IMHO, the selected approach is too inflexible.  Some people find it
+;; difficult to read code that uses a 2 column width indentation.
+;;
+;; A very strict yet better and respectful approach would have been to impose
+;; a 2 column indentation with a 2-column width hard-tab with line length
+;; computing the hard-tab as a 2 column width.  That would have allowed people
+;; to increase tab width to a larger value to widen the rendering of
+;; indentation on their screen without any impact on the file's content.
+;;
+;; PEL implements a solution to this problem: an automated conversion of
+;; space-indented files into tab-indented buffers with ability to change the
+;; tab width.  For Dart, this special minor mode is activated by the
+;; `pel-indent-with-tabs-mode-for-dart' user-option.
+;;
+
+;;  Major Mode Dispatcher: `pel-dart-mode'
+;;  * `pel-dart-mode'
+;;  - `pel--dart-ts-mode-fixer'
+;;
+;;  Indentation Control Information
+;;  * `pel-dart-indent-tab-info'
+;;    - `pel-dart-insert-indent-info'
+;;    - `pel-dart-insert-tab-info'
+;;
+;;  Major Mode Setup Information
+;;  * `pel-dart-setup-info'
+;;    - `pel--dart-minor-mode-info'
 
 ;;; --------------------------------------------------------------------------
 ;;; Dependencies:
@@ -82,6 +96,9 @@
 ;;; --------------------------------------------------------------------------
 ;;; Code:
 ;;
+
+;;* Major Mode Dispatcher: `pel-dart-mode'
+;;  ======================================
 
 ;;-pel-autoload
 (defun pel-dart-mode ()
@@ -113,15 +130,154 @@ and required by `pel-use-dart'."
         (user-error
          "Can't use `dart-ts-mode' nor `dart-mode': check installation!"))))))
 
+;; Emacs tree-sitter handling fixer function.
+;; Identified by `pel--ts-mode-with-fixer' and used by `pel-eval-after-load'.
 ;;-pel-autoload
 (defun pel--dart-ts-mode-fixer ()
   "Remove `dart-ts-mode' entries from `auto-mode-alist'.
-It removes what entered when `dart-ts-mode' loads."
+It removes what was entered when `dart-ts-mode' loads to ensure that the
+`pel-dart-mode' mode dispatcher remains used."
   ;; There are several file extensions for Dart and the dart-ts-mode
   ;; adds several entries (entries for .dart, .zon).
   ;; Delete them all from auto-mode-alist.
   (setq auto-mode-alist
         (rassq-delete-all 'dart-ts-mode auto-mode-alist)))
+
+;; ---------------------------------------------------------------------------
+;;* Indentation Control Information
+;;  ===============================
+;;
+;; Define a set of major-mode specific call back functions that are called
+;; by the `pel-show-indent' command.  The call backs are invoked indirectly.
+;; The `pel-indent-control-context' infer the names of the call back functions
+;; using the name of the major mode and a format string.
+;;
+;; The call back functions are:
+;; - `pel-dart-insert-indent-info' : Insert non-inferred indentation control.
+;; - `pel-dart-insert-tab-info'    : Insert tab control info.
+;; - `pel-dart-indent-tab-info'    : Tab information command.
+
+;; Define the function called by `pel-indent-control-context' used by the
+;; command `pel-show-indent' to insert the indentation control user option.
+
+;;-pel-autoload
+(defun pel-dart-insert-indent-info ()
+  "Insert Dart indentation and hard tab setup info in current context.
+Return a list of generic symbols described by this function."
+  ;; `pel-indent-insert-control-info' identifies the dart indentation control
+  ;; variable via a call to `pel-mode-indent-control-vars' which uses
+  ;; `pel-mode-or-ts-mode-indent-control-vars' to identify
+  ;; `dart-ts-indent-offset'.  Therefore no user-option value/link is
+  ;; inserted here, just a note that only Tree-Sitter mode variable is used.
+  (insert "\nDart has no classic mode.")
+  ;; Return the list of generic symbols this function inserts.
+  ;; These symbols are later used to identify the information already
+  ;; inserted.
+  '(indent-description-info))
+
+
+;;-pel-autoload
+(defun pel-dart-insert-tab-info ()
+  "Insert Dart indentation and hard tab setup info in current context.
+Return a list of generic symbols described by this function."
+  (insert (substitute-command-keys "
+ The Dart designers are pushing for an 2-column indentation
+ made of space only. No tabs.
+
+ See https://github.com/dart-lang/dart/discussions/3633
+
+ However, several people find the 2-column indentation too small.
+ If this is the case for you, and you work on official Dart code,
+ you could use a temporary use a `tab-width' of 2, tabify the code
+ with \\[tabify], then change the `tab-width' to a larger value
+ for wider indentation.
+
+ You can disable the format on save while you work on that file.
+ When you're done just untabify the code with \\[untabify].
+
+ PEL can automate all that: simply activate the
+ `pel-indent-with-tabs-mode-for-dart'  user-option below.
+ This does the same as the tbindent-mode implemented
+ as a separate package.
+"))
+  (pel-insert-symbol-content-line 'pel-dart-tab-width)
+  (pel-insert-symbol-content-line 'pel-dart-use-tabs
+                                  nil #'pel-on-off-string)
+  ;; Return the list of generic symbols described here.
+  '(tab-description-intro
+    pel-MM-tab-width
+    pel-MM-use-tabs))
+
+;;-pel-autoload
+(defun pel-dart-indent-tab-info (&optional append)
+  "Display Dart Indentation and hard tab control information."
+  (interactive "P")
+  (pel-major-mode-must-be 'dart-ts-mode)
+  (let ((indent-control-context (pel-indent-control-context))
+        (tab-control-context (pel-tab-control-context))
+        (format-on-save (pel--symbol-value 'dart-ts-format-on-save :quiet)))
+    (pel-print-in-buffer
+     "*pel-indent-info*"
+     "Indentation Width Control and Space/Tab Insertion Rendering"
+     (lambda ()
+       (pel-indent-insert-control-info indent-control-context)
+       (pel-tab-insert-control-info tab-control-context)
+       (when format-on-save
+         (insert "\n
+     Remember: the Dart formatter imposes its own style and is executed
+               when the buffer is saved.  If you want to use a different
+               format you will need to turn it off:")
+         (pel-insert-symbol-content-line 'dart-ts-format-on-save)))
+     (unless append :clear-buffer)
+     :use-help-mode)))
+
+;; ---------------------------------------------------------------------------
+;;* Major Mode Setup Information
+;; =============================
+
+;;-pel-autoload
+(defun pel--dart-minor-mode-info ()
+  "Insert information related to Dart minor modes."
+  (insert "
+Automatic activation of minor mode is also controlled by the
+following user-options:")
+  (pel-insert-list-content 'pel-dart-activates-minor-modes
+                           nil nil nil :1line))
+
+;;-pel-autoload
+(defun pel-dart-setup-info (&optional append)
+  "Display Dart setup information."
+  (interactive "P")
+  (pel-major-mode-must-be '(dart-mode dart-ts-mode))
+  (let ((pel-insert-symbol-content-context-buffer (current-buffer))
+        (current-major-mode major-mode)
+        (active-modes (pel-active-minor-modes))
+        (indent-control-context (pel-indent-control-context))
+        (tab-control-context (pel-tab-control-context)))
+    (pel-print-in-buffer
+     "*pel-dart-info*"
+     "PEL setup for Dart programming language"
+     (lambda ()
+       "Print Dart setup"
+       (insert (propertize "* Major Mode Control:" 'face 'bold))
+       (pel-insert-symbol-content 'major-mode nil :on-same-line nil
+                                  "major mode currently used")
+       (when pel-use-tree-sitter
+         (insert (format "\n- %s" (pel-ts-language-grammar-status-for
+                                   'dart "\n- "))))
+       (insert "\n\n")
+       ;; -- List of minor modes
+       (pel-insert-list-of-minor-modes active-modes)
+       (insert "\n\n")
+       (pel-insert-minor-mode-activation-info current-major-mode
+                                              #'pel--dart-minor-mode-info)
+       ;; --
+       (insert "\n\n")
+       (pel-indent-insert-control-info indent-control-context)
+       (pel-tab-insert-control-info tab-control-context)
+       )
+     (unless append :clear-buffer)
+     :use-help-mode)))
 
 ;;; --------------------------------------------------------------------------
 (provide 'pel-dart)

--- a/pel-dart.el
+++ b/pel-dart.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, November  4 2025.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-13 22:30:47 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-13 22:41:35 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -212,7 +212,7 @@ Return a list of generic symbols described by this function."
 (defun pel-dart-indent-tab-info (&optional append)
   "Display Dart Indentation and hard tab control information."
   (interactive "P")
-  (pel-major-mode-must-be 'dart-ts-mode)
+  (pel-major-mode-must-be '(dart-mode dart-ts-mode))
   (let ((indent-control-context (pel-indent-control-context))
         (tab-control-context (pel-tab-control-context))
         (format-on-save (pel--symbol-value 'dart-ts-format-on-save :quiet)))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Completed Dart setup information functionality. Users can now view detailed Dart configuration information including major-mode status, active grammar, running plugins, and indentation/tab control settings via the dedicated setup info command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->