### PR TITLE
Cleanup: use pel-insert-bold. Describe fixer. Fix ada major mode info.

### DIFF
--- a/pel-ada.el
+++ b/pel-ada.el
@@ -2,12 +2,12 @@
 
 ;; Created   : Friday, October 17 2025.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2025-12-05 16:45:22 EST, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-13 23:26:37 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
 
-;; Copyright (C) 2025  Pierre Rouleau
+;; Copyright (C) 2025, 2026  Pierre Rouleau
 ;;
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -72,10 +72,13 @@ and required by `pel-use-ada'."
         (user-error
          "Can't use `ada-ts-mode' nor `ada-mode': check installation!"))))))
 
+;; Emacs tree-sitter handling fixer function.
+;; Identified by `pel--ts-mode-with-fixer' and used by `pel-eval-after-load'.
 ;;-pel-autoload
 (defun pel--ada-ts-mode-fixer ()
   "Remove `ada-ts-mode' entries from `auto-mode-alist'.
-It removes what entered when `ada-ts-mode' loads."
+It removes what was entered when `ada-ts-mode' loads to ensure that the
+`pel-ada-mode' mode dispatcher remains used."
   ;; There are several file extensions for Ada and the ada-ts-mode
   ;; adds several entries (entries for .ada, .zon).
   ;; Delete them all from auto-mode-alist.
@@ -167,6 +170,7 @@ following user-options:")
   (pel-major-mode-must-be '(ada-mode ada-ts-mode))
   (let ((pel-insert-symbol-content-context-buffer (current-buffer))
         (current-major-mode major-mode)
+        (active-modes (pel-active-minor-modes))
         (indent-control-context (pel-indent-control-context))
         (tab-control-context (pel-tab-control-context)))
     (pel-print-in-buffer
@@ -174,7 +178,7 @@ following user-options:")
      "PEL setup for Ada programming language"
      (lambda ()
        "Print Ada setup info."
-       (insert (propertize "* Major Mode Control:" 'face 'bold))
+       (pel-insert-bold "* Major Mode Control:")
        (pel-insert-symbol-content 'major-mode nil :on-same-line nil
                                   "major mode currently used")
        (when pel-use-tree-sitter
@@ -187,7 +191,9 @@ following user-options:")
          (unless (eq pel-use-ada 'with-tree-sitter)
            (insert "\n Unless you have a specific reason to not use it, you should.")))
        (insert "\n\n")
-       ;; --
+       ;; -- List of minor modes
+       (pel-insert-list-of-minor-modes active-modes)
+       (insert "\n\n")
        (pel-insert-minor-mode-activation-info current-major-mode
                                               #'pel--ada-minor-mode-info)
        (insert "\n\n")

--- a/pel-c3.el
+++ b/pel-c3.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, December 23 2025.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-03-18 11:13:30 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-13 23:23:57 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -119,7 +119,7 @@ following user-options:")
      "PEL setup for C3 programming language"
      (lambda ()
        "Print C3 setup"
-       (insert (propertize "* Major Mode Control:" 'face 'bold))
+       (pel-insert-bold "* Major Mode Control:")
        (insert "
 - Note: C3 is currently only supported by a Tree-Sitter aware mode.")
        (pel-insert-symbol-content 'major-mode nil :on-same-line nil

--- a/pel-elixir.el
+++ b/pel-elixir.el
@@ -2,12 +2,12 @@
 
 ;; Created   : Tuesday, October 14 2025.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2025-12-05 16:45:33 EST, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-13 23:22:16 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
 
-;; Copyright (C) 2025  Pierre Rouleau
+;; Copyright (C) 2025, 2026  Pierre Rouleau
 ;;
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -75,10 +75,13 @@ and required by `pel-use-elixir'."
         (user-error
          "Can't use `elixir-ts-mode' nor `elixir-mode': check installation!"))))))
 
+;; Emacs tree-sitter handling fixer function.
+;; Identified by `pel--ts-mode-with-fixer' and used by `pel-eval-after-load'.
 ;;-pel-autoload
 (defun pel--elixir-ts-mode-fixer ()
   "Remove `elixir-ts-mode' entries from `auto-mode-alist'.
-It removes what entered when `elixir-ts-mode' loads."
+It removes what was entered when `elixir-ts-mode' loads to ensure that the
+`pel-elixir-mode' mode dispatcher remains used."
   ;; There are several file extensions for Elixir and the elixir-ts-mode
   ;; adds several entries (entries for .elixir, .ex, .exs, mix.lock).
   ;; Delete them all from auto-mode-alist.
@@ -171,7 +174,7 @@ following user-options:")
      "PEL setup for Elixir programming language"
      (lambda ()
        "Print Elixir setup info."
-       (insert (propertize "* Major Mode Control:" 'face 'bold))
+       (pel-insert-bold "* Major Mode Control:")
        (pel-insert-symbol-content 'major-mode nil :on-same-line nil
                                   "major mode currently used")
        (when pel-use-tree-sitter

--- a/pel-erlang.el
+++ b/pel-erlang.el
@@ -159,10 +159,13 @@ and required by `pel-use-erlang'."
         (user-error
          "Can't use `erlang-ts-mode' nor `erlang-mode': check installation!"))))))
 
+;; Emacs tree-sitter handling fixer function.
+;; Identified by `pel--ts-mode-with-fixer' and used by `pel-eval-after-load'.
 ;;-pel-autoload
 (defun pel--erlang-ts-mode-fixer ()
   "Remove `erlang-ts-mode' entries from `auto-mode-alist'.
-It removes what entered when `erlang-ts-mode' loads."
+It removes what was entered when `erlang-ts-mode' loads to ensure that the
+`pel-erlang-mode' mode dispatcher remains used."
   ;; There are several file extensions for Erlang and the erlang-ts-mode
   ;; adds several entries (entries for .erlang, .ex, .exs, mix.lock).
   ;; Delete them all from auto-mode-alist.
@@ -268,7 +271,7 @@ following user-options:")
      "PEL setup for Erlang programming language"
      (lambda ()
        "Print Erlang setup info."
-       (insert (propertize "* Major Mode Control:" 'face 'bold))
+       (pel-insert-bold "* Major Mode Control:")
        (pel-insert-symbol-content 'major-mode nil :on-same-line nil
                                   "major mode currently used")
        (when pel-use-tree-sitter

--- a/pel-forth.el
+++ b/pel-forth.el
@@ -2,12 +2,12 @@
 
 ;; Created   : Friday, October 17 2025.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2025-12-05 16:45:50 EST, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-13 23:20:57 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
 
-;; Copyright (C) 2025  Pierre Rouleau
+;; Copyright (C) 2025, 2026  Pierre Rouleau
 ;;
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -112,7 +112,7 @@ following user-options:")
      "PEL setup for Forth programming language"
      (lambda ()
        "Print Forth setup info."
-       (insert (propertize "* Major Mode Control:" 'face 'bold))
+       (pel-insert-bold "* Major Mode Control:")
        (pel-insert-symbol-content 'major-mode nil :on-same-line nil
                                   "major mode currently used")
        (insert "

--- a/pel-indent.el
+++ b/pel-indent.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Saturday, February 29 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-03-26 22:55:48 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-13 23:20:27 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -640,6 +640,7 @@ Return the new `tab-width' or nil if unchanged."
                           fsharp-indent-level
                           fsharp-indent-offset))
     (gdscript-mode       gdscript-indent-offset)
+    (gleam-mode          gleam-ts-indent-offset)
     (go-ts-mode          go-ts-mode-indent-offset)
     (gpr-ts-mode         gpr-ts-mode-indent-offset)
     (groovy-mode         groovy-indent-offset) ; Groovy
@@ -832,7 +833,7 @@ important variables and symbols in the context of the inspected major mode."
          (major-mode-specific-inserted nil)
          (pel-controls-indentation nil))
     ;; 2- insert information using those values
-    (insert (propertize "* Indentation Control:" 'face 'bold))
+    (pel-insert-bold "* Indentation Control:")
     ;;    - insert mode specialized info if a function exists for it.
     (when (fboundp indent-indent-info-inserter-fct)
       (setq already-inserted (funcall indent-indent-info-inserter-fct))
@@ -979,7 +980,7 @@ important variables and symbols in the context of the inspected major mode."
          (mode-base (pel-file-type-for used-major-mode)))
     ;; 2- insert information using those values
     (insert "\n\n")
-    (insert (propertize "* Hard Tab Control:" 'face 'bold))
+    (pel-insert-bold "* Hard Tab Control:")
     (when (fboundp indent-tab-info-inserter-fct)
       (setq already-inserted (funcall indent-tab-info-inserter-fct)))
     (when (and (not (memq 'tab-description-intro already-inserted))
@@ -1080,7 +1081,9 @@ With APPEND optional argument non-nil, append to the buffer."
   (let ((indent-tab-info-cmd (intern (pel-string-with-major-mode
                                       "pel-%s-indent-tab-info"))))
     (if (fboundp indent-tab-info-cmd)
+        ;; if a mode specific function exists, use it.
         (call-interactively indent-tab-info-cmd)
+      ;; otherwise use the lower level call backs.
       (let ((indent-control-context (pel-indent-control-context))
             (tab-control-context (pel-tab-control-context)))
         (pel-print-in-buffer

--- a/pel-js.el
+++ b/pel-js.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Monday, October 20 2025.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-03-26 14:42:43 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-13 23:19:45 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -75,10 +75,13 @@ and required by `pel-use-js'."
         (user-error
          "Can't use `js-ts-mode' nor `js-mode': check installation!"))))))
 
+;; Emacs tree-sitter handling fixer function.
+;; Identified by `pel--ts-mode-with-fixer' and used by `pel-eval-after-load'.
 ;;-pel-autoload
 (defun pel--js-ts-mode-fixer ()
   "Remove `js-ts-mode' entries from `auto-mode-alist'.
-It removes what entered when `js-ts-mode' loads."
+It removes what was entered when `js-ts-mode' loads to ensure that the
+`pel-js-mode' mode dispatcher remains used."
   ;; There are several file extensions for Javascript and the `js-ts-mode'
   ;; adds several entries (entries for .js, .zon).
   ;; Delete them all from auto-mode-alist.
@@ -213,7 +216,7 @@ following user-options:")
      "PEL setup for Javascript programming language"
      (lambda ()
        "Print Javascript setup info."
-       (insert (propertize "* Major Mode Control:" 'face 'bold))
+       (pel-insert-bold "* Major Mode Control:")
        (pel-insert-symbol-content 'major-mode nil :on-same-line nil
                                   "major mode currently used")
        (when pel-use-tree-sitter

--- a/pel-lua.el
+++ b/pel-lua.el
@@ -2,12 +2,12 @@
 
 ;; Created   : Monday, March 19 2025.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2025-12-05 16:46:43 EST, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-13 23:19:14 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
 
-;; Copyright (C) 2025  Pierre Rouleau
+;; Copyright (C) 2025, 2026  Pierre Rouleau
 ;;
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -91,10 +91,13 @@ the selection made by `pel-lua-repl-used'."
       (error "lua-start-process is not bound."))))
 
 
+;; Emacs tree-sitter handling fixer function.
+;; Identified by `pel--ts-mode-with-fixer' and used by `pel-eval-after-load'.
 ;;-pel-autoload
 (defun pel--lua-ts-mode-fixer ()
   "Remove `lua-ts-mode' entries from `auto-mode-alist'.
-It removes what entered when `lua-ts-mode' loads."
+It removes what was entered when `lua-ts-mode' loads to ensure that
+`pel-lua-mode' mode dispatcher remains used."
   ;; There are several file extensions for Lua and the lua-ts-mode
   ;; adds several entries (entries for .lua).
   ;; Delete them all from auto-mode-alist.
@@ -189,7 +192,7 @@ following user-options:")
      "PEL setup for Lua programming language"
      (lambda ()
        "Print Lua setup info."
-       (insert (propertize "* Major Mode Control:" 'face 'bold))
+       (pel-insert-bold "* Major Mode Control:")
        (pel-insert-symbol-content 'major-mode nil :on-same-line nil
                                   "major mode currently used")
        (when pel-use-tree-sitter

--- a/pel-nim.el
+++ b/pel-nim.el
@@ -2,12 +2,12 @@
 
 ;; Created   : Monday, March 19 2025.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2025-12-05 16:46:51 EST, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-13 23:18:38 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
 
-;; Copyright (C) 2025  Pierre Rouleau
+;; Copyright (C) 2025, 2026  Pierre Rouleau
 ;;
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -130,7 +130,7 @@ following user-options:")
      "PEL setup for Nim programming language"
      (lambda ()
        "Print Nim setup info."
-       (insert (propertize "* Major Mode Control:" 'face 'bold))
+       (pel-insert-bold "* Major Mode Control:")
        (pel-insert-symbol-content 'major-mode nil :on-same-line nil
                                   "major mode currently used")
        (insert "

--- a/pel-ruby.el
+++ b/pel-ruby.el
@@ -2,12 +2,12 @@
 
 ;; Created   : Monday, March 19 2025.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2025-12-05 16:59:56 EST, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-13 23:17:42 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
 
-;; Copyright (C) 2025  Pierre Rouleau
+;; Copyright (C) 2025, 2026  Pierre Rouleau
 ;;
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -75,10 +75,13 @@ and required by `pel-use-ruby'."
         (user-error
          "Can't use `ruby-ts-mode' nor `ruby-mode': check installation!"))))))
 
+;; Emacs tree-sitter handling fixer function.
+;; Identified by `pel--ts-mode-with-fixer' and used by `pel-eval-after-load'.
 ;;-pel-autoload
 (defun pel--ruby-ts-mode-fixer ()
   "Remove `ruby-ts-mode' entries from `auto-mode-alist'.
-It removes what entered when `ruby-ts-mode' loads."
+It removes what was entered when `ruby-ts-mode' loads to ensure that the
+`pel-ruby-mode' mode dispatcher remains used."
   ;; There are several file extensions for Ruby and the ruby-ts-mode
   ;; adds several entries (entries for all Ruby files).
   ;; Delete them all from auto-mode-alist.
@@ -171,7 +174,7 @@ following user-options:")
      "PEL setup for Ruby programming language"
      (lambda ()
        "Print Ruby setup info."
-       (insert (propertize "* Major Mode Control:" 'face 'bold))
+       (pel-insert-bold "* Major Mode Control:")
        (pel-insert-symbol-content 'major-mode nil :on-same-line nil
                                   "major mode currently used")
        (when pel-use-tree-sitter

--- a/pel-rust.el
+++ b/pel-rust.el
@@ -2,12 +2,12 @@
 
 ;; Created   : Sunday, October 12 2025.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2025-12-05 17:00:39 EST, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-13 23:16:55 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
 
-;; Copyright (C) 2025  Pierre Rouleau
+;; Copyright (C) 2025, 2026  Pierre Rouleau
 ;;
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -75,10 +75,13 @@ and required by `pel-use-rust'."
         (user-error
          "Can't use `rust-ts-mode' nor `rust-mode': check installation!"))))))
 
+;; Emacs tree-sitter handling fixer function.
+;; Identified by `pel--ts-mode-with-fixer' and used by `pel-eval-after-load'.
 ;;-pel-autoload`
 (defun pel--rust-ts-mode-fixer ()
   "Remove `rust-ts-mode' entries from `auto-mode-alist'.
-It removes what entered when `rust-ts-mode' loads."
+It removes what was entered when `rust-ts-mode' loads to ensure that the
+`pel-rust-mode' mode dispatcher remains used."
   (setq auto-mode-alist
         (rassq-delete-all 'rust-ts-mode auto-mode-alist)))
 
@@ -165,7 +168,7 @@ following user-options:")
      (lambda ()
        "Print Rust setup info."
        ;;
-       (insert (propertize "* Major Mode Control:" 'face 'bold))
+       (pel-insert-bold "* Major Mode Control:")
        (pel-insert-symbol-content 'major-mode nil :on-same-line nil
                                   "major mode currently used")
        (when pel-use-tree-sitter
@@ -175,7 +178,7 @@ following user-options:")
                                        (function pel-rust-mode-used-text))
        (insert "\n\n")
        ;;
-       (insert (propertize "* Rust Packages:" 'face 'bold))
+       (pel-insert-bold "* Rust Packages:")
        (dolist (s '(pel-use-rust-mode
                     pel-use-rustic
                     pel-use-cargo

--- a/pel-tcl.el
+++ b/pel-tcl.el
@@ -2,12 +2,12 @@
 
 ;; Created   : Monday, March 17 2025.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2025-12-05 17:01:17 EST, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-13 23:16:10 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
 
-;; Copyright (C) 2025  Pierre Rouleau
+;; Copyright (C) 2025, 2026  Pierre Rouleau
 ;;
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -123,7 +123,7 @@ following user-options:")
      "PEL setup for Tcl programming language"
      (lambda ()
        "Print Tcl setup info."
-       (insert (propertize "* Major Mode Control:" 'face 'bold))
+       (pel-insert-bold "* Major Mode Control:")
        (pel-insert-symbol-content 'major-mode nil :on-same-line nil
                                   "major mode currently used")
        (insert "

--- a/pel-timestamp.el
+++ b/pel-timestamp.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, June 10 2025.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-03-26 14:42:28 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-13 23:15:38 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -93,9 +93,7 @@ The information is shown inside a *pel-time-stamp-info* help buffer."
      "*pel-time-stamp-info*"
      "Automatic File Time Stamp Control"
      (lambda ()
-       ;; (insert (propertize  "* Control Time Stamp Update on File Save:"
-       ;;                      'face
-       ;;                      'bold))
+       ;; (pel-insert-bold "* Control Time Stamp Update on File Save:")
        (insert (substitute-command-keys "
 PEL provides control of the hook logic required to automate the update
 of time stamp when a file is saved; it controls it with the value of the
@@ -123,8 +121,7 @@ function that updates time stamp when it is non-nil.
         "Only controls whether time-stamp command updates the time stamp.")
 
        (insert "\n\n")
-       (insert (propertize  "*Time Stamp Location and Format Control:" 'face
-                            'bold))
+       (pel-insert-bold "*Time Stamp Location and Format Control:")
        (insert "
 
 The location and format of the time stamp is either controlled by the single

--- a/pel-zig.el
+++ b/pel-zig.el
@@ -2,12 +2,12 @@
 
 ;; Created   : Tuesday, October 14 2025.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2025-12-05 16:48:43 EST, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-13 23:14:58 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
 
-;; Copyright (C) 2025  Pierre Rouleau
+;; Copyright (C) 2025, 2026  Pierre Rouleau
 ;;
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -75,10 +75,13 @@ and required by `pel-use-zig'."
         (user-error
          "Can't use `zig-ts-mode' nor `zig-mode': check installation!"))))))
 
+;; Emacs tree-sitter handling fixer function.
+;; Identified by `pel--ts-mode-with-fixer' and used by `pel-eval-after-load'.
 ;;-pel-autoload
 (defun pel--zig-ts-mode-fixer ()
   "Remove `zig-ts-mode' entries from `auto-mode-alist'.
-It removes what entered when `zig-ts-mode' loads."
+It removes what was entered when `zig-ts-mode' loads to ensure that the
+`pel-zig-mode' mode dispatcher remains used."
   ;; There are several file extensions for Zig and the zig-ts-mode
   ;; adds several entries (entries for .zig, .zon).
   ;; Delete them all from auto-mode-alist.
@@ -172,7 +175,7 @@ following user-options:")
      "PEL setup for Zig programming language"
      (lambda ()
        "Print Zig setup info."
-       (insert (propertize "* Major Mode Control:" 'face 'bold))
+       (pel-insert-bold "* Major Mode Control:")
        (pel-insert-symbol-content 'major-mode nil :on-same-line nil
                                   "major mode currently used")
        (when pel-use-tree-sitter
@@ -182,7 +185,7 @@ following user-options:")
                                        (function pel-zig-mode-used-text))
        (insert "\n\n")
        ;;
-       (insert (propertize "* Code Formatting Control:" 'face 'bold))
+       (pel-insert-bold "* Code Formatting Control:")
        (pel-insert-symbol-content-line 'zig-format-on-save)
        ;; -- List of minor modes
        (pel-insert-list-of-minor-modes active-modes)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gleam language indentation support
  * Extended Ada setup information to display active minor modes

* **Documentation**
  * Clarified mode dispatcher function documentation across language modules

* **Refactor**
  * Unified bold text formatting in setup information displays across multiple modules
  * Updated file metadata and copyright years

<!-- end of auto-generated comment: release notes by coderabbit.ai -->