### PR TITLE
Move pel-prompt-for-filename in pel-prompt.el

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-2026 by Pierre Rouleau
 
 # Author: Pierre Rouleau <prouleau001@gmail.com>
-# Last Modified Time-stamp: <2026-03-29 10:33:19 EDT, updated by Pierre Rouleau>
+# Last Modified Time-stamp: <2026-04-15 10:59:10 EDT, updated by Pierre Rouleau>
 # Keywords: packaging, build-control
 
 # This file is part of the PEL package
@@ -934,6 +934,7 @@ test/pel-list-test.el.test-passed:              pel-list.elc
 test/pel-open-test.el.test-passed:              pel--base.elc pel-open.elc
 test/pel-mark-test.el.test-passed:              pel-mark.elc pel--base.elc
 test/pel-package-test.el.test-passed:           pel-package.elc pel--base.elc pel--options.elc
+test/pel-prompt-test.el.test-passed:            pel-prompt.elc
 test/pel-seq-test.el.test-passed:               pel-seq.elc
 test/pel-skel-c-test.el.test-passed:            pel--options.elc
 test/pel-skel-clisp-test.el.test-passed:        pel--options.elc

--- a/pel-file.el
+++ b/pel-file.el
@@ -27,17 +27,17 @@
 ;; location, and then open the file inside a specified Emacs window or the URL
 ;; inside an external process frame.
 ;;
-;; The point can be located anywhere inside the file or URL in all
-;; cases except when the file name includes embedded spaces.  To
-;; extract a file name with embedded spaces, the file name must be
-;; enclosed with double quotes and the point must be located on the
-;; opening quote.  Line and column numbers are also supported.
+;; The point can be located anywhere inside the file or URL in all cases
+;; except when the file name includes embedded spaces.  To extract a file name
+;; with embedded spaces, the file name must be enclosed with double quotes and
+;; the point must be located on the opening quote.  Line and column numbers
+;; are also supported.
 ;;
 ;; The file is opened inside a specific window if it is specified by numeric
 ;; argument.  If a window already contains the file and no argument specify
-;; where to open the file, just move point to that window.  The numeric argument
-;; identify a cardinal direction to the target window.  If the pointed window is
-;; the minibuffer or a dedicated window the command fails.
+;; where to open the file, just move point to that window.  The numeric
+;; argument identify a cardinal direction to the target window.  If the
+;; pointed window is the minibuffer or a dedicated window the command fails.
 ;;
 ;; Credits: The pathstop string with Unicode block characters
 ;;          originally borrowed from Xah Lee's xah-open-file-at-cursor
@@ -58,7 +58,6 @@
 ;;     - pel--show-edit-action
 ;;   - pel--complete-filename-for
 ;;     - pel--lib-filename
-;;       - pel-prompt-for-filename
 ;;   - pel--show-edit-action
 ;;
 ;; * pel-show-filename-parts-at-point
@@ -300,34 +299,6 @@ but *only* when the complete string is enclosed in double quotes
          ;; When nothing matches, return nil
          (t nil)
          )))))
-
-(defun pel-prompt-for-filename (default-filename)
-  "Prompt for a file name, with DEFAULT-FILENAME shown.
-The DEFAULT-FILENAME must be a string or nil.
-User can either accept the filename or modify it.
-If the file does not already exist, a confirmation is requested.
-Returns the filename string."
-  (unless default-filename
-    (setq default-filename ""))
-  ;; read-file-name is flexible but I find it non-obvious. To get it to show
-  ;; the filename, it seems to have to be placed in the DIR argument.
-  ;; With it a single word (no path) will be interpreted as a file in the local
-  ;; directory (which is what I want).
-  ;; MUSTMATCH and PREDICATE are set to ensure the file exists.  If it does not
-  ;; the user must confirm and then the caller can create it.
-  (expand-file-name (read-file-name
-                     ;; PROMPT
-                     "Open? (C-g to quit): "
-                     ;; DIR
-                     default-filename
-                     ;; DEFAULT_FILENAME
-                     nil
-                     ;; MUSTMATCH
-                     'confirm
-                     ;; INITIAL
-                     nil
-                     ;; PREDICATE
-                     'file-exists-p)))
 
 (defun pel--lib-filename (filename)
   "Infer or prompt for library filename using incomplete FILENAME.

--- a/pel-prompt.el
+++ b/pel-prompt.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Saturday, February 29 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-15 17:19:45 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-16 08:46:28 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package
 ;; This file is not part of GNU Emacs.
@@ -111,7 +111,7 @@ This keymap is used by `pel-y-n-e-or-l-p'.")
 
 ;;-pel-autoload
 (defun pel-y-n-e-or-l-p (prompt)
-  "Ask user a \"y, n or e\" question.
+  "Ask user a \"y, n, e or l\" question.
 Return:
 - \\='yes     if the answer is \"y\",
 - \\='no      if it is \"n\",
@@ -229,11 +229,13 @@ SELECTION is a list of (char prompt value).
 CURRENT optionally identifies the currently used value.  It may hold the
 special value :no-current-value to prevent display of current value.
 
-SELECTION is printed right after TITLE, without any separating space,
-when CURRENT is :no-current-value.  If you want to separate them you
-need to include a space at the end of TITLE.  However, when a CURRENT
-value is shown, the trailing space in TITLE are ignored and the CURRENT
-value is shown in brackets following TITLE and one space.
+A \"Select\" prefix then SELECTION is printed right after TITLE, without
+space before \"Select\", when CURRENT is :no-current-value.
+If you want to separate them you need to include a space at the end of
+TITLE.  However, when a CURRENT value is shown, the trailing space in
+TITLE are ignored and the CURRENT value is shown in brackets following
+TITLE and one space.  This way it becomes possible to generate prompts
+with an empty title and no space before the selection text.
 
 NIL-VALUE optional string identifies meaning for a nil value.  It is
 required when the USER-OPTION may be set to the same thing by one value
@@ -349,6 +351,8 @@ The prompt mechanism is using the back-end selected by
 `pel-prompt-read-method' user-option."
   (cl-case pel-prompt-read-method
     ((nil)
+     ;; When default read method is used use index starting at 0 to get at
+     ;; least 10 choices with numeric indices.
      (pel-select-string-from prompt strings ?0))
     ((ivy)
      (if  (and (require 'ivy nil :noerror)
@@ -554,11 +558,12 @@ minibuffer for editing."
                      "Open? (C-g to quit): "
                      ;; DIR
                      default-filename
-                     ;; DEFAULT_FILENAME
+                     ;; DEFAULT-FILENAME
                      nil
                      ;; MUSTMATCH
                      'confirm
-                     ;; INITIAL
+                     ;; INITIAL: nil to prevent combination with DIR and
+                     ;; there's no (other) file name to start with.
                      nil
                      ;; PREDICATE
                      'file-exists-p)))

--- a/pel-prompt.el
+++ b/pel-prompt.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Saturday, February 29 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-15 08:13:24 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-15 11:16:30 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package
 ;; This file is not part of GNU Emacs.
@@ -145,7 +145,7 @@ y/Y (yes), n/N (no), e/E (edit), l/L (library).\n")
      (noninteractive
       (setq prompt (funcall padded prompt))
       (let ((temp-prompt prompt))
-        (while (not (memq answer '(act skip edit-replacement automatic)))
+        (while (not (memq answer '(yes no edit findlib)))
           (let ((str (read-string temp-prompt)))
             (cond ((member str '("y" "Y")) (setq answer 'yes))
                   ((member str '("n" "N")) (setq answer 'no))

--- a/pel-prompt.el
+++ b/pel-prompt.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Saturday, February 29 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-15 17:02:01 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-15 17:19:45 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package
 ;; This file is not part of GNU Emacs.
@@ -538,8 +538,10 @@ Returns the expanded filename string.
 Note: default-filename is passed as the DIR argument to read-file-name —
 not as the default filename — so that its value is displayed in the
 minibuffer for editing."
-  (unless default-filename
-    (setq default-filename ""))
+  (unless (or (null default-filename)
+              (stringp default-filename))
+    (signal 'wrong-type-argument (list 'stringp default-filename)))
+  (setq default-filename (or default-filename ""))
   ;; `read-file-name' is flexible but I find it non-obvious.
   ;; To get it to show the filename, it has to be placed in the DIR argument.
   ;; With a single word (no path) will be interpreted as a file in the local

--- a/pel-prompt.el
+++ b/pel-prompt.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Saturday, February 29 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-15 11:44:59 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-15 17:02:01 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package
 ;; This file is not part of GNU Emacs.
@@ -30,13 +30,15 @@
 ;; The file defines the following functions:
 ;;
 ;; - `pel-y-n-e-or-l-p'
-;; - `pel-set-user-option'
-;; - `pel-select-string-from'
 ;; - `pel-select-symbol-from'
 ;;   - `pel-select-from'
 ;;     - `pel--prompt-for'
 ;;       - `pel--var-value-description'
+;; - `pel-select-string-from'
+;; - `pel-prompt-select-read'
+;; - `pel-set-user-option'
 ;; - `pel-prompt-purpose-for'
+;; - `pel-prompt-class'
 ;; - `pel-prompt-function'
 ;; - `pel-prompt-args'
 ;; - `pel-prompt'
@@ -105,7 +107,7 @@
 The \"bindings\" in this map are not commands; they are answers.
 The valid answers include `yes', `no', `edit' and `findlib'.
 
-This keymap is used by `pel-y-n-e-or-l-p'")
+This keymap is used by `pel-y-n-e-or-l-p'.")
 
 ;;-pel-autoload
 (defun pel-y-n-e-or-l-p (prompt)
@@ -114,7 +116,7 @@ Return:
 - \\='yes     if the answer is \"y\",
 - \\='no      if it is \"n\",
 - \\='edit    if it is \"e\", or
-- \\='findlib if it is \"!\".
+- \\='findlib if it is \"l\".
 PROMPT is the string to display to ask the question.
 It should end in a space;
 `pel-y-n-e-or-l-p' adds \"(y, n, e or l) \" to it.
@@ -194,7 +196,7 @@ y/Y (yes), n/N (no), e/E (edit), l/L (library).\n")
             ((eq answer 'no)        '(no   . ?n))
             ((eq answer 'edit)      '(edit . ?e))
             ((eq answer 'findlib)   '(findlib . ?l))
-            (t nil))))
+            (t (error "Invalid answer: %S" answer)))))
       (unless noninteractive
         (message "%s%c" prompt (cdr retl)))
       (car retl))))
@@ -221,16 +223,26 @@ Each choice is a list of 3 elements:
 
 (defun pel--prompt-for (title selection &optional current nil-value)
   "Return a prompt string with TITLE for SELECTION.
+
+TITLE is the first string displayed on the prompt.
 SELECTION is a list of (char prompt value).
-CURRENT optionally identifies the currently used value.  It may hold
-the spacial value :no-current-value to prevent display of current value.
+CURRENT optionally identifies the currently used value.  It may hold the
+special value :no-current-value to prevent display of current value.
+
+SELECTION is printed right after TITLE, without any separating space,
+when CURRENT is :no-current-value.  If you want to separate them you
+need to include a space at the end of TITLE.  However, when a CURRENT
+value is shown, the trailing space in TITLE are ignored and the CURRENT
+value is shown in brackets following TITLE and one space.
 
 NIL-VALUE optional string identifies meaning for a nil value.  It is
-required when the USER-OPTION may be set to the same thing by one
-value in the SELECTION but also by the nil value, and that nil
-value is not part of the SELECTION."
+required when the USER-OPTION may be set to the same thing by one value
+in the SELECTION but also by the nil value, and that nil value is not
+part of the SELECTION."
   (format "%s%s: %s."
-          title
+          (if (eq current :no-current-value)
+              title
+            (string-trim title))
           (if (eq current :no-current-value)
               "Select"
             (let ((initial-value (or (pel--var-value-description current
@@ -307,9 +319,9 @@ SYMBOLS := a list of symbols."
 
 (defun pel-select-string-from (title strings &optional first-idx)
   "Prompt with a TITLE to select from a set of STRINGS.
+Return the selected string.
 The list of choices use index characters starting at 1 unless
 FIRST-IDX is provided: a character.
-Return the selected symbol.
 TITLE   := a prompt string.  It should end with a space.
 STRINGS := a list of strings."
   (let* ((choices ())
@@ -445,9 +457,11 @@ Holds an independent function prompt history for each major mode."
 
 (defun pel-prompt-args (&optional transform-function)
   "Prompt for argument(s) and return potentially transformed input string.
-If TRANSFORM-FUNCTION is non-nil it must be a function that accepts
-the function var-name string and return it transformed or nil if the function
-var-name is not acceptable.
+
+If TRANSFORM-FUNCTION is non-nil it must be a function that accepts the
+ argument string and return it transformed or nil if the argument is not
+ acceptable.
+
 Holds an independent function prompt history for each major mode."
   (let ((history-symbol (intern
                          (format
@@ -519,7 +533,11 @@ If WITH-FULL-STOP is non-nil a period is added if user did not enter one."
 The DEFAULT-FILENAME must be a string or nil.
 User can either accept the filename or modify it.
 If the file does not already exist, a confirmation is requested.
-Returns the expanded filename string."
+Returns the expanded filename string.
+
+Note: default-filename is passed as the DIR argument to read-file-name —
+not as the default filename — so that its value is displayed in the
+minibuffer for editing."
   (unless default-filename
     (setq default-filename ""))
   ;; `read-file-name' is flexible but I find it non-obvious.

--- a/pel-prompt.el
+++ b/pel-prompt.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Saturday, February 29 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-15 11:16:30 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-15 11:44:59 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package
 ;; This file is not part of GNU Emacs.
@@ -400,7 +400,7 @@ returns DEFAULT."
      (string-trim
       (read-from-minibuffer prompt-text nil nil nil history-symbol))
      (function pel-hastext)
-     default
+     (or default "")
      (function pel-capitalize-first-letter)
      (lambda (v)
        (if no-ending-period

--- a/pel-prompt.el
+++ b/pel-prompt.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Saturday, February 29 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-03-23 12:07:50 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-15 08:13:24 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package
 ;; This file is not part of GNU Emacs.
@@ -42,6 +42,7 @@
 ;; - `pel-prompt'
 ;; - `pel-prompt-with-completion'
 ;; - `pel-prompt-title'
+;; - `pel-prompt-for-filename'
 ;;
 ;; The `pel-y-n-e-or-l-p' function is a minor modification of the Emacs'
 ;; y-or-n-p.  It has the ability to type "e" or "E" as an answer to
@@ -77,6 +78,7 @@
 (require 'pel--options)               ; use: `pel-prompt-read-method'
 (require 'pel-text-transform)         ; use: `pel-capitalize-first-letter'
 (require 'subr-x)                     ; use: `string-trim'
+(require 'minibuffer)                 ; use: `read-file-name'
 (eval-when-compile
   (require 'cl-lib)                   ; use: `cl-dolist' and `cl-return'
   (require 'cl-macs))                 ; use: `cl-case'.
@@ -509,6 +511,37 @@ If WITH-FULL-STOP is non-nil a period is added if user did not enter one."
         (pel-end-text-with-period title)
       title)))
 
+;; ---------------------------------------------------------------------------
+;; Prompt for File
+
+(defun pel-prompt-for-filename (&optional default-filename)
+  "Prompt for a file name, showing DEFAULT-FILENAME if specified.
+The DEFAULT-FILENAME must be a string or nil.
+User can either accept the filename or modify it.
+If the file does not already exist, a confirmation is requested.
+Returns the expanded filename string."
+  (unless default-filename
+    (setq default-filename ""))
+  ;; `read-file-name' is flexible but I find it non-obvious.
+  ;; To get it to show the filename, it has to be placed in the DIR argument.
+  ;; With a single word (no path) will be interpreted as a file in the local
+  ;; directory (which is what I want).
+  ;; MUSTMATCH and PREDICATE are set to ensure the file exists.
+  ;; If it does not exist the user must confirm and then the caller can create
+  ;; it.
+  (expand-file-name (read-file-name
+                     ;; PROMPT
+                     "Open? (C-g to quit): "
+                     ;; DIR
+                     default-filename
+                     ;; DEFAULT_FILENAME
+                     nil
+                     ;; MUSTMATCH
+                     'confirm
+                     ;; INITIAL
+                     nil
+                     ;; PREDICATE
+                     'file-exists-p)))
 ;; -----------------------------------------------------------------------------
 (provide 'pel-prompt)
 

--- a/test/pel-prompt-test.el
+++ b/test/pel-prompt-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Wednesday, April 15 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-15 11:45:12 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-15 17:07:34 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -146,12 +146,6 @@
 ;;; -------------------------------------------------------------------------
 ;;; Tests for `pel-y-n-e-or-l-p' (noninteractive branch)
 ;;
-;; NOTE: These tests require the bug fix described above.  Until the while
-;; loop exit condition is corrected from:
-;;   (not (memq answer '(act skip edit-replacement automatic)))
-;; to:
-;;   (not (memq answer '(yes no edit findlib)))
-;; these tests will hang indefinitely.
 
 (ert-deftest test-pel-y-n-e-or-l-p/noninteractive-y ()
   "Returns `yes' for input \"y\" in noninteractive mode."
@@ -313,7 +307,7 @@
   "Omits period when NO-ENDING-PERIOD is non-nil."
   (pel-test--with-minibuffer-input "Does something"
     (should (equal "Does something"
-                   (pel-prompt-purpose-for "function" nil :no-period)))))
+                   (pel-prompt-purpose-for "function" nil 'no-period)))))
 
 (ert-deftest test-pel-prompt-purpose-for/empty-input-returns-default ()
   "Returns DEFAULT when user enters nothing."

--- a/test/pel-prompt-test.el
+++ b/test/pel-prompt-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Wednesday, April 15 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-15 11:08:01 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-15 11:22:28 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -155,63 +155,54 @@
 
 (ert-deftest test-pel-y-n-e-or-l-p/noninteractive-y ()
   "Returns `yes' for input \"y\" in noninteractive mode."
-  (ert-skip "Skip tests that hangs.")
   (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "y")))
     (let ((noninteractive t))
       (should (eq 'yes (pel-y-n-e-or-l-p "Test? "))))))
 
 (ert-deftest test-pel-y-n-e-or-l-p/noninteractive-Y ()
   "Returns `yes' for uppercase \"Y\" in noninteractive mode."
-  (ert-skip "Skip tests that hangs.")
   (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "Y")))
     (let ((noninteractive t))
       (should (eq 'yes (pel-y-n-e-or-l-p "Test? "))))))
 
 (ert-deftest test-pel-y-n-e-or-l-p/noninteractive-n ()
   "Returns `no' for input \"n\" in noninteractive mode."
-  (ert-skip "Skip tests that hangs.")
   (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "n")))
     (let ((noninteractive t))
       (should (eq 'no (pel-y-n-e-or-l-p "Test? "))))))
 
 (ert-deftest test-pel-y-n-e-or-l-p/noninteractive-N ()
   "Returns `no' for uppercase \"N\" in noninteractive mode."
-  (ert-skip "Skip test that hangs")
   (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "N")))
     (let ((noninteractive t))
       (should (eq 'no (pel-y-n-e-or-l-p "Test? "))))))
 
 (ert-deftest test-pel-y-n-e-or-l-p/noninteractive-e ()
   "Returns `edit' for input \"e\" in noninteractive mode."
-  (ert-skip "Skip tests that hangs.")
   (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "e")))
     (let ((noninteractive t))
       (should (eq 'edit (pel-y-n-e-or-l-p "Test? "))))))
 
 (ert-deftest test-pel-y-n-e-or-l-p/noninteractive-E ()
   "Returns `edit' for uppercase \"E\" in noninteractive mode."
-  (ert-skip "Skip test that hangs.")
   (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "E")))
     (let ((noninteractive t))
       (should (eq 'edit (pel-y-n-e-or-l-p "Test? "))))))
 
 (ert-deftest test-pel-y-n-e-or-l-p/noninteractive-l ()
   "Returns `findlib' for input \"l\" in noninteractive mode."
-  (ert-skip "Skip test that hangs.")
   (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "l")))
     (let ((noninteractive t))
       (should (eq 'findlib (pel-y-n-e-or-l-p "Test? "))))))
 
 (ert-deftest test-pel-y-n-e-or-l-p/noninteractive-L ()
   "Returns `findlib' for uppercase \"L\" in noninteractive mode."
-  (ert-skip "Skip test that hangs.")
   (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "L")))
     (let ((noninteractive t))
       (should (eq 'findlib (pel-y-n-e-or-l-p "Test? "))))))
 
 (ert-deftest test-pel-y-n-e-or-l-p/noninteractive-retry-on-bad-input ()
   "Re-prompts on invalid input; accepts valid input on retry."
-  (ert-skip "Skip test that hangs.")
   (let ((call-count 0))
     (cl-letf (((symbol-function 'read-string)
                (lambda (&rest _)
@@ -332,7 +323,7 @@
 
 (ert-deftest test-pel-prompt-purpose-for/empty-input-no-default-returns-empty ()
   "Returns empty string when input is empty and no default given."
-  (ert-skip "Temporary skip test that fails ")
+  (ert-skip "Temporary skip test that fails.")
   (pel-test--with-minibuffer-input ""
     (should (equal "" (pel-prompt-purpose-for "function")))))
 
@@ -481,7 +472,6 @@
 
 (ert-deftest test-pel-prompt-for-filename/nil-default-becomes-empty-string ()
   "Passes empty string as DIR when DEFAULT-FILENAME is nil."
-  (ert-skip "Temporary skip test that fails on: (wrong-number-of-arguments #<subr identity> 2)")
   (let (captured-dir)
     (cl-letf (((symbol-function 'read-file-name)
                (lambda (_prompt dir &rest _)
@@ -493,7 +483,6 @@
 
 (ert-deftest test-pel-prompt-for-filename/no-arg-uses-empty-dir ()
   "Passes empty string as DIR when called with no argument."
-  (ert-skip "Temporary skip test that fails on: (wrong-number-of-arguments #<subr identity> 2)")
   (let (captured-dir)
     (cl-letf (((symbol-function 'read-file-name)
                (lambda (_prompt dir &rest _)
@@ -505,7 +494,6 @@
 
 (ert-deftest test-pel-prompt-for-filename/string-default-passed-as-dir ()
   "Passes DEFAULT-FILENAME as the DIR argument."
-  (ert-skip "Temporary skip test that fails on: (wrong-number-of-arguments #<subr identity> 2)")
   (let (captured-dir)
     (cl-letf (((symbol-function 'read-file-name)
                (lambda (_prompt dir &rest _)
@@ -517,7 +505,6 @@
 
 (ert-deftest test-pel-prompt-for-filename/returns-expanded-name ()
   "Returns the result of `expand-file-name' on `read-file-name' output."
-  (ert-skip "Temporary skip test that fails on: (wrong-number-of-arguments (1 . 1) 2)")
   (cl-letf (((symbol-function 'read-file-name)
              (lambda (&rest _) "relative/path.txt"))
             ((symbol-function 'expand-file-name)
@@ -527,7 +514,6 @@
 
 (ert-deftest test-pel-prompt-for-filename/uses-confirm-mustmatch ()
   "Passes `confirm' as the MUSTMATCH argument."
-  (ert-skip "Temporary skip test that fails on: (wrong-number-of-arguments #<subr identity> 2)")
   (let (captured-mustmatch)
     (cl-letf (((symbol-function 'read-file-name)
                (lambda (_prompt _dir _default mustmatch &rest _)
@@ -539,7 +525,6 @@
 
 (ert-deftest test-pel-prompt-for-filename/uses-file-exists-p-predicate ()
   "Passes `file-exists-p' as the PREDICATE argument."
-  (ert-skip "Temporary skip test that fails on: (wrong-number-of-arguments #<subr identity> 2)")
   (let (captured-pred)
     (cl-letf (((symbol-function 'read-file-name)
                (lambda (_prompt _dir _default _mustmatch _initial pred)
@@ -551,7 +536,6 @@
 
 (ert-deftest test-pel-prompt-for-filename/correct-prompt-text ()
   "Uses the exact prompt string \"Open? (C-g to quit): \"."
-  (ert-skip "Temporary skip test that fails on: (wrong-number-of-arguments #<subr identity> 2)")
   (let (captured-prompt)
     (cl-letf (((symbol-function 'read-file-name)
                (lambda (prompt &rest _)
@@ -563,7 +547,6 @@
 
 (ert-deftest test-pel-prompt-for-filename/nil-default-filename-arg ()
   "Passes nil as DEFAULT_FILENAME (3rd arg) to `read-file-name'."
-  (ert-skip "Temporary skip test that fails on: (wrong-number-of-arguments #<subr identity> 2)")
   (let (captured-default)
     (cl-letf (((symbol-function 'read-file-name)
                (lambda (_prompt _dir default &rest _)

--- a/test/pel-prompt-test.el
+++ b/test/pel-prompt-test.el
@@ -1,0 +1,614 @@
+;;; pel-prompt-test.el --- Test the pel-prompt.el  -*- lexical-binding: t; -*-
+
+;; Created   : Wednesday, April 15 2026.
+;; Author    : Pierre Rouleau <prouleau001@gmail.com>
+;; Time-stamp: <2026-04-15 11:08:01 EDT, updated by Pierre Rouleau>
+
+;; This file is part of the PEL package.
+;; This file is not part of GNU Emacs.
+
+;; Copyright (C) 2026  Pierre Rouleau
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; --------------------------------------------------------------------------
+;;; Commentary:
+;;
+;;
+
+;;; --------------------------------------------------------------------------
+;;; Dependencies:
+;;
+;;
+(require 'pel-prompt)
+(require 'ert)
+(require 'cl-lib)
+
+;;; --------------------------------------------------------------------------
+;;; Code:
+;;
+;;; -------------------------------------------------------------------------
+;;; Helpers / shared macros
+
+(defmacro pel-test--with-read-char-choice (char &rest body)
+  "Execute BODY with `read-char-choice' mocked to return CHAR."
+  (declare (indent 1))
+  `(cl-letf (((symbol-function 'read-char-choice) (lambda (&rest _) ,char)))
+     ,@body))
+
+(defmacro pel-test--with-minibuffer-input (input &rest body)
+  "Execute BODY with `read-from-minibuffer' mocked to return INPUT."
+  (declare (indent 1))
+  `(cl-letf (((symbol-function 'read-from-minibuffer) (lambda (&rest _) ,input)))
+     ,@body))
+
+;;; -------------------------------------------------------------------------
+;;; Tests for `pel--var-value-description'
+
+(ert-deftest test-pel--var-value-description/found-first ()
+  "Returns description of the first entry when VALUE matches it."
+  (should (equal "Alpha"
+                 (pel--var-value-description
+                  'alpha
+                  '((?a "Alpha" alpha) (?b "Beta" beta))))))
+
+(ert-deftest test-pel--var-value-description/found-last ()
+  "Returns description of the last entry when VALUE matches it."
+  (should (equal "Gamma"
+                 (pel--var-value-description
+                  'gamma
+                  '((?a "Alpha" alpha) (?b "Beta" beta) (?c "Gamma" gamma))))))
+
+(ert-deftest test-pel--var-value-description/not-found ()
+  "Returns nil when VALUE is absent from SELECTION."
+  (should (null (pel--var-value-description
+                 'delta
+                 '((?a "Alpha" alpha) (?b "Beta" beta))))))
+
+(ert-deftest test-pel--var-value-description/empty-selection ()
+  "Returns nil for an empty SELECTION list."
+  (should (null (pel--var-value-description 'alpha '()))))
+
+(ert-deftest test-pel--var-value-description/integer-value ()
+  "Works correctly with integer values."
+  (should (equal "One"
+                 (pel--var-value-description
+                  1
+                  '((?1 "One" 1) (?2 "Two" 2))))))
+
+;;; -------------------------------------------------------------------------
+;;; Tests for `pel--prompt-for'
+
+(ert-deftest test-pel--prompt-for/no-current-value-keyword ()
+  "Contains \"Select\" and title when CURRENT is `:no-current-value'."
+  (let ((result (pel--prompt-for
+                 "Test"
+                 '((?1 "One" one) (?2 "Two" two))
+                 :no-current-value)))
+    (should (stringp result))
+    (should (string-match-p "Test"   result))
+    (should (string-match-p "Select" result))))
+
+(ert-deftest test-pel--prompt-for/known-current-value-shown-in-brackets ()
+  "Shows current value description in square brackets."
+  (let ((result (pel--prompt-for
+                 "Pick"
+                 '((?1 "One" one) (?2 "Two" two))
+                 'one)))
+    (should (string-match-p "\\[One\\]" result))))
+
+(ert-deftest test-pel--prompt-for/unknown-current-value-no-brackets ()
+  "No brackets shown when CURRENT is not in SELECTION."
+  (let ((result (pel--prompt-for
+                 "Pick"
+                 '((?1 "One" one) (?2 "Two" two))
+                 'three)))
+    (should-not (string-match-p "\\[" result))))
+
+(ert-deftest test-pel--prompt-for/nil-value-label-shown ()
+  "NIL-VALUE label appears in brackets for a nil CURRENT."
+  (let ((result (pel--prompt-for
+                 "Pick"
+                 '((?1 "One" one) (?2 "Two" two))
+                 nil
+                 "nothing")))
+    (should (string-match-p "\\[nothing\\]" result))))
+
+(ert-deftest test-pel--prompt-for/all-choices-present ()
+  "All choice description strings appear in the prompt."
+  (let ((result (pel--prompt-for
+                 "Choose"
+                 '((?a "Alpha" alpha) (?b "Beta" beta) (?c "Gamma" gamma))
+                 :no-current-value)))
+    (should (string-match-p "Alpha" result))
+    (should (string-match-p "Beta"  result))
+    (should (string-match-p "Gamma" result))))
+
+(ert-deftest test-pel--prompt-for/ends-with-period ()
+  "Prompt string ends with a period (as per format spec)."
+  (let ((result (pel--prompt-for
+                 "Test"
+                 '((?1 "One" one))
+                 :no-current-value)))
+    (should (string-suffix-p "." result))))
+
+;;; -------------------------------------------------------------------------
+;;; Tests for `pel-y-n-e-or-l-p' (noninteractive branch)
+;;
+;; NOTE: These tests require the bug fix described above.  Until the while
+;; loop exit condition is corrected from:
+;;   (not (memq answer '(act skip edit-replacement automatic)))
+;; to:
+;;   (not (memq answer '(yes no edit findlib)))
+;; these tests will hang indefinitely.
+
+(ert-deftest test-pel-y-n-e-or-l-p/noninteractive-y ()
+  "Returns `yes' for input \"y\" in noninteractive mode."
+  (ert-skip "Skip tests that hangs.")
+  (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "y")))
+    (let ((noninteractive t))
+      (should (eq 'yes (pel-y-n-e-or-l-p "Test? "))))))
+
+(ert-deftest test-pel-y-n-e-or-l-p/noninteractive-Y ()
+  "Returns `yes' for uppercase \"Y\" in noninteractive mode."
+  (ert-skip "Skip tests that hangs.")
+  (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "Y")))
+    (let ((noninteractive t))
+      (should (eq 'yes (pel-y-n-e-or-l-p "Test? "))))))
+
+(ert-deftest test-pel-y-n-e-or-l-p/noninteractive-n ()
+  "Returns `no' for input \"n\" in noninteractive mode."
+  (ert-skip "Skip tests that hangs.")
+  (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "n")))
+    (let ((noninteractive t))
+      (should (eq 'no (pel-y-n-e-or-l-p "Test? "))))))
+
+(ert-deftest test-pel-y-n-e-or-l-p/noninteractive-N ()
+  "Returns `no' for uppercase \"N\" in noninteractive mode."
+  (ert-skip "Skip test that hangs")
+  (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "N")))
+    (let ((noninteractive t))
+      (should (eq 'no (pel-y-n-e-or-l-p "Test? "))))))
+
+(ert-deftest test-pel-y-n-e-or-l-p/noninteractive-e ()
+  "Returns `edit' for input \"e\" in noninteractive mode."
+  (ert-skip "Skip tests that hangs.")
+  (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "e")))
+    (let ((noninteractive t))
+      (should (eq 'edit (pel-y-n-e-or-l-p "Test? "))))))
+
+(ert-deftest test-pel-y-n-e-or-l-p/noninteractive-E ()
+  "Returns `edit' for uppercase \"E\" in noninteractive mode."
+  (ert-skip "Skip test that hangs.")
+  (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "E")))
+    (let ((noninteractive t))
+      (should (eq 'edit (pel-y-n-e-or-l-p "Test? "))))))
+
+(ert-deftest test-pel-y-n-e-or-l-p/noninteractive-l ()
+  "Returns `findlib' for input \"l\" in noninteractive mode."
+  (ert-skip "Skip test that hangs.")
+  (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "l")))
+    (let ((noninteractive t))
+      (should (eq 'findlib (pel-y-n-e-or-l-p "Test? "))))))
+
+(ert-deftest test-pel-y-n-e-or-l-p/noninteractive-L ()
+  "Returns `findlib' for uppercase \"L\" in noninteractive mode."
+  (ert-skip "Skip test that hangs.")
+  (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "L")))
+    (let ((noninteractive t))
+      (should (eq 'findlib (pel-y-n-e-or-l-p "Test? "))))))
+
+(ert-deftest test-pel-y-n-e-or-l-p/noninteractive-retry-on-bad-input ()
+  "Re-prompts on invalid input; accepts valid input on retry."
+  (ert-skip "Skip test that hangs.")
+  (let ((call-count 0))
+    (cl-letf (((symbol-function 'read-string)
+               (lambda (&rest _)
+                 (cl-incf call-count)
+                 (if (= call-count 1) "x" "y"))))
+      (let ((noninteractive t))
+        (should (eq 'yes (pel-y-n-e-or-l-p "Test? ")))
+        (should (= 2 call-count))))))
+
+;;; -------------------------------------------------------------------------
+;;; Tests for `pel-select-from'
+
+(ert-deftest test-pel-select-from/returns-matching-value ()
+  "Returns the value mapped to the selected character."
+  (let ((sel '((?a "Alpha" alpha) (?b "Beta" beta))))
+    (pel-test--with-read-char-choice ?a
+      (should (eq 'alpha (pel-select-from "T" sel))))
+    (pel-test--with-read-char-choice ?b
+      (should (eq 'beta (pel-select-from "T" sel))))))
+
+(ert-deftest test-pel-select-from/calls-action-with-value ()
+  "Calls ACTION with the selected value when it differs from CURRENT."
+  (let ((sel '((?a "Alpha" alpha) (?b "Beta" beta)))
+        (received nil))
+    (pel-test--with-read-char-choice ?b
+      (pel-select-from "T" sel nil (lambda (v) (setq received v) v)))
+    (should (eq 'beta received))))
+
+(ert-deftest test-pel-select-from/no-action-when-same-as-current ()
+  "ACTION is NOT called when the selected value equals CURRENT-VALUE."
+  (let ((sel '((?a "Alpha" alpha) (?b "Beta" beta)))
+        (called nil))
+    (pel-test--with-read-char-choice ?a
+      (pel-select-from "T" sel 'alpha (lambda (v) (setq called t) v)))
+    (should-not called)))
+
+(ert-deftest test-pel-select-from/always-perform-action-flag ()
+  "ACTION IS called even when value equals CURRENT when flag is non-nil."
+  (let ((sel '((?a "Alpha" alpha) (?b "Beta" beta)))
+        (called nil))
+    (pel-test--with-read-char-choice ?a
+      (pel-select-from "T" sel 'alpha (lambda (v) (setq called t) v) nil t))
+    (should called)))
+
+(ert-deftest test-pel-select-from/returns-value-without-action ()
+  "Returns the selected value directly when no ACTION is given."
+  (let ((sel '((?a "Alpha" alpha) (?b "Beta" beta))))
+    (pel-test--with-read-char-choice ?b
+      (should (eq 'beta (pel-select-from "T" sel))))))
+
+;;; -------------------------------------------------------------------------
+;;; Tests for `pel-select-symbol-from'
+
+(ert-deftest test-pel-select-symbol-from/first-symbol ()
+  "Returns the first symbol when key ?1 is pressed."
+  (cl-letf (((symbol-function 'read-char-choice) (lambda (&rest _) ?1))
+            ((symbol-function 'message) #'ignore))
+    (should (eq 'foo
+                (pel-select-symbol-from "Pick: " '(foo bar baz))))))
+
+(ert-deftest test-pel-select-symbol-from/second-symbol ()
+  "Returns the second symbol when key ?2 is pressed."
+  (cl-letf (((symbol-function 'read-char-choice) (lambda (&rest _) ?2))
+            ((symbol-function 'message) #'ignore))
+    (should (eq 'bar
+                (pel-select-symbol-from "Pick: " '(foo bar baz))))))
+
+(ert-deftest test-pel-select-symbol-from/custom-first-idx ()
+  "Respects a custom FIRST-IDX start character."
+  (cl-letf (((symbol-function 'read-char-choice) (lambda (&rest _) ?a))
+            ((symbol-function 'message) #'ignore))
+    (should (eq 'foo
+                (pel-select-symbol-from "Pick: " '(foo bar) ?a)))))
+
+;;; -------------------------------------------------------------------------
+;;; Tests for `pel-select-string-from'
+
+(ert-deftest test-pel-select-string-from/first-string ()
+  "Returns the first string when key ?1 is pressed."
+  (cl-letf (((symbol-function 'read-char-choice) (lambda (&rest _) ?1))
+            ((symbol-function 'message) #'ignore))
+    (should (equal "apple"
+                   (pel-select-string-from "Pick: " '("apple" "banana"))))))
+
+(ert-deftest test-pel-select-string-from/second-string ()
+  "Returns the second string when key ?2 is pressed."
+  (cl-letf (((symbol-function 'read-char-choice) (lambda (&rest _) ?2))
+            ((symbol-function 'message) #'ignore))
+    (should (equal "banana"
+                   (pel-select-string-from "Pick: " '("apple" "banana"))))))
+
+;;; -------------------------------------------------------------------------
+;;; Tests for `pel-prompt-purpose-for'
+
+(ert-deftest test-pel-prompt-purpose-for/capitalizes-and-adds-period ()
+  "Returns trimmed, capitalised, period-terminated string."
+  (pel-test--with-minibuffer-input "  handles file creation  "
+    (should (equal "Handles file creation."
+                   (pel-prompt-purpose-for "function")))))
+
+(ert-deftest test-pel-prompt-purpose-for/no-double-period ()
+  "Does not append a second period when input already ends with one."
+  (pel-test--with-minibuffer-input "Does something."
+    (should (equal "Does something."
+                   (pel-prompt-purpose-for "function")))))
+
+(ert-deftest test-pel-prompt-purpose-for/no-ending-period-flag ()
+  "Omits period when NO-ENDING-PERIOD is non-nil."
+  (pel-test--with-minibuffer-input "Does something"
+    (should (equal "Does something"
+                   (pel-prompt-purpose-for "function" nil :no-period)))))
+
+(ert-deftest test-pel-prompt-purpose-for/empty-input-returns-default ()
+  "Returns DEFAULT when user enters nothing."
+  (pel-test--with-minibuffer-input ""
+    (should (equal "Fallback purpose."
+                   (pel-prompt-purpose-for "function" "Fallback purpose.")))))
+
+(ert-deftest test-pel-prompt-purpose-for/empty-input-no-default-returns-empty ()
+  "Returns empty string when input is empty and no default given."
+  (ert-skip "Temporary skip test that fails ")
+  (pel-test--with-minibuffer-input ""
+    (should (equal "" (pel-prompt-purpose-for "function")))))
+
+(ert-deftest test-pel-prompt-purpose-for/independent-history-per-item ()
+  "Does not signal an error when called for two different items."
+  (pel-test--with-minibuffer-input "Does X."
+    (should (equal "Does X." (pel-prompt-purpose-for "alpha"))))
+  (pel-test--with-minibuffer-input "Does Y."
+    (should (equal "Does Y." (pel-prompt-purpose-for "beta")))))
+
+;;; -------------------------------------------------------------------------
+;;; Tests for `pel-prompt-function'
+
+(ert-deftest test-pel-prompt-function/returns-trimmed-name ()
+  "Returns the trimmed function name."
+  (pel-test--with-minibuffer-input "  my-func  "
+    (should (equal "my-func" (pel-prompt-function)))))
+
+(ert-deftest test-pel-prompt-function/applies-transform ()
+  "Applies TRANSFORM-FUNCTION to the entered string."
+  (pel-test--with-minibuffer-input "my-func"
+    (should (equal "MY-FUNC" (pel-prompt-function #'upcase)))))
+
+(ert-deftest test-pel-prompt-function/transform-nil-retries ()
+  "Re-prompts when TRANSFORM-FUNCTION returns nil (simulated via counter)."
+  (let ((call-count 0))
+    (cl-letf (((symbol-function 'read-from-minibuffer)
+               (lambda (&rest _)
+                 (cl-incf call-count)
+                 (if (= call-count 1) "bad" "good"))))
+      (should (equal "good"
+                     (pel-prompt-function
+                      (lambda (s) (and (equal s "good") s))))))))
+
+;;; -------------------------------------------------------------------------
+;;; Tests for `pel-prompt-class'
+
+(ert-deftest test-pel-prompt-class/returns-trimmed-name ()
+  "Returns the trimmed class name."
+  (pel-test--with-minibuffer-input "  MyClass  "
+    (should (equal "MyClass" (pel-prompt-class)))))
+
+(ert-deftest test-pel-prompt-class/applies-transform ()
+  "Applies TRANSFORM-CLASS to the entered string."
+  (pel-test--with-minibuffer-input "myclass"
+    (should (equal "MYCLASS" (pel-prompt-class #'upcase)))))
+
+;;; -------------------------------------------------------------------------
+;;; Tests for `pel-prompt-args'
+
+(ert-deftest test-pel-prompt-args/returns-trimmed-args ()
+  "Returns the trimmed argument string."
+  (pel-test--with-minibuffer-input "  arg1 arg2  "
+    (should (equal "arg1 arg2" (pel-prompt-args)))))
+
+(ert-deftest test-pel-prompt-args/applies-transform ()
+  "Applies TRANSFORM-FUNCTION to the entered argument string."
+  (pel-test--with-minibuffer-input "arg1"
+    (should (equal "ARG1" (pel-prompt-args #'upcase)))))
+
+;;; -------------------------------------------------------------------------
+;;; Tests for `pel-prompt'
+
+(ert-deftest test-pel-prompt/returns-trimmed-string ()
+  "Returns the trimmed user input."
+  (pel-test--with-minibuffer-input "  hello world  "
+    (should (equal "hello world" (pel-prompt "Enter")))))
+
+(ert-deftest test-pel-prompt/capitalize ()
+  "Returns string with first letter capitalised when CAPITALIZE is non-nil."
+  (pel-test--with-minibuffer-input "hello world"
+    (should (equal "Hello world" (pel-prompt "Enter" nil :capitalize)))))
+
+(ert-deftest test-pel-prompt/no-capitalize ()
+  "Preserves case when CAPITALIZE is nil."
+  (pel-test--with-minibuffer-input "hello World"
+    (should (equal "hello World" (pel-prompt "Enter" nil nil)))))
+
+(ert-deftest test-pel-prompt/with-scope ()
+  "Works without error when a SCOPE symbol is provided."
+  (pel-test--with-minibuffer-input "result"
+    (should (equal "result" (pel-prompt "Enter" 'my-scope)))))
+
+(ert-deftest test-pel-prompt/empty-input ()
+  "Returns empty string for empty user input."
+  (pel-test--with-minibuffer-input ""
+    (should (equal "" (pel-prompt "Enter")))))
+
+;;; -------------------------------------------------------------------------
+;;; Tests for `pel-prompt-with-completion'
+
+(ert-deftest test-pel-prompt-with-completion/returns-selection ()
+  "Returns the value that `completing-read' produces."
+  (cl-letf (((symbol-function 'completing-read)
+             (lambda (_prompt collection &rest _) (car collection))))
+    (should (equal "alpha"
+                   (pel-prompt-with-completion "Pick: " '("alpha" "beta"))))))
+
+(ert-deftest test-pel-prompt-with-completion/passes-prompt ()
+  "Passes the PROMPT string to `completing-read' unchanged."
+  (let (captured-prompt)
+    (cl-letf (((symbol-function 'completing-read)
+               (lambda (p c &rest _)
+                 (setq captured-prompt p)
+                 (car c))))
+      (pel-prompt-with-completion "My prompt: " '("a"))
+      (should (equal "My prompt: " captured-prompt)))))
+
+(ert-deftest test-pel-prompt-with-completion/with-scope ()
+  "Does not signal an error when SCOPE is provided."
+  (cl-letf (((symbol-function 'completing-read)
+             (lambda (_p c &rest _) (car c))))
+    (should (equal "x"
+                   (pel-prompt-with-completion "P: " '("x" "y") 'my-scope)))))
+
+;;; -------------------------------------------------------------------------
+;;; Tests for `pel-prompt-title'
+
+(ert-deftest test-pel-prompt-title/capitalizes-first-letter ()
+  "Returns title with first letter capitalised."
+  (pel-test--with-minibuffer-input "my title"
+    (should (equal "My title" (pel-prompt-title)))))
+
+(ert-deftest test-pel-prompt-title/no-period-by-default ()
+  "Does not append a period when WITH-FULL-STOP is nil."
+  (pel-test--with-minibuffer-input "my title"
+    (should-not (string-suffix-p "." (pel-prompt-title)))))
+
+(ert-deftest test-pel-prompt-title/with-full-stop-appends-period ()
+  "Appends a period when WITH-FULL-STOP is non-nil and title lacks one."
+  (pel-test--with-minibuffer-input "my title"
+    (should (string-suffix-p "." (pel-prompt-title :full-stop)))))
+
+(ert-deftest test-pel-prompt-title/no-double-period ()
+  "Does not add a second period when title already ends with one."
+  (pel-test--with-minibuffer-input "my title."
+    (should (equal "My title." (pel-prompt-title :full-stop)))))
+
+(ert-deftest test-pel-prompt-title/empty-input ()
+  "Returns empty string for empty user input."
+  (pel-test--with-minibuffer-input ""
+    (should (equal "" (pel-prompt-title)))))
+
+;;; -------------------------------------------------------------------------
+;;; Tests for `pel-prompt-for-filename'
+
+(ert-deftest test-pel-prompt-for-filename/nil-default-becomes-empty-string ()
+  "Passes empty string as DIR when DEFAULT-FILENAME is nil."
+  (ert-skip "Temporary skip test that fails on: (wrong-number-of-arguments #<subr identity> 2)")
+  (let (captured-dir)
+    (cl-letf (((symbol-function 'read-file-name)
+               (lambda (_prompt dir &rest _)
+                 (setq captured-dir dir)
+                 "/some/file.txt"))
+              ((symbol-function 'expand-file-name) #'identity))
+      (pel-prompt-for-filename nil)
+      (should (equal "" captured-dir)))))
+
+(ert-deftest test-pel-prompt-for-filename/no-arg-uses-empty-dir ()
+  "Passes empty string as DIR when called with no argument."
+  (ert-skip "Temporary skip test that fails on: (wrong-number-of-arguments #<subr identity> 2)")
+  (let (captured-dir)
+    (cl-letf (((symbol-function 'read-file-name)
+               (lambda (_prompt dir &rest _)
+                 (setq captured-dir dir)
+                 "/some/file.txt"))
+              ((symbol-function 'expand-file-name) #'identity))
+      (pel-prompt-for-filename)
+      (should (equal "" captured-dir)))))
+
+(ert-deftest test-pel-prompt-for-filename/string-default-passed-as-dir ()
+  "Passes DEFAULT-FILENAME as the DIR argument."
+  (ert-skip "Temporary skip test that fails on: (wrong-number-of-arguments #<subr identity> 2)")
+  (let (captured-dir)
+    (cl-letf (((symbol-function 'read-file-name)
+               (lambda (_prompt dir &rest _)
+                 (setq captured-dir dir)
+                 "/some/file.txt"))
+              ((symbol-function 'expand-file-name) #'identity))
+      (pel-prompt-for-filename "myfile.txt")
+      (should (equal "myfile.txt" captured-dir)))))
+
+(ert-deftest test-pel-prompt-for-filename/returns-expanded-name ()
+  "Returns the result of `expand-file-name' on `read-file-name' output."
+  (ert-skip "Temporary skip test that fails on: (wrong-number-of-arguments (1 . 1) 2)")
+  (cl-letf (((symbol-function 'read-file-name)
+             (lambda (&rest _) "relative/path.txt"))
+            ((symbol-function 'expand-file-name)
+             (lambda (f) (concat "/root/" f))))
+    (should (equal "/root/relative/path.txt"
+                   (pel-prompt-for-filename)))))
+
+(ert-deftest test-pel-prompt-for-filename/uses-confirm-mustmatch ()
+  "Passes `confirm' as the MUSTMATCH argument."
+  (ert-skip "Temporary skip test that fails on: (wrong-number-of-arguments #<subr identity> 2)")
+  (let (captured-mustmatch)
+    (cl-letf (((symbol-function 'read-file-name)
+               (lambda (_prompt _dir _default mustmatch &rest _)
+                 (setq captured-mustmatch mustmatch)
+                 "/f.txt"))
+              ((symbol-function 'expand-file-name) #'identity))
+      (pel-prompt-for-filename)
+      (should (eq 'confirm captured-mustmatch)))))
+
+(ert-deftest test-pel-prompt-for-filename/uses-file-exists-p-predicate ()
+  "Passes `file-exists-p' as the PREDICATE argument."
+  (ert-skip "Temporary skip test that fails on: (wrong-number-of-arguments #<subr identity> 2)")
+  (let (captured-pred)
+    (cl-letf (((symbol-function 'read-file-name)
+               (lambda (_prompt _dir _default _mustmatch _initial pred)
+                 (setq captured-pred pred)
+                 "/f.txt"))
+              ((symbol-function 'expand-file-name) #'identity))
+      (pel-prompt-for-filename)
+      (should (eq 'file-exists-p captured-pred)))))
+
+(ert-deftest test-pel-prompt-for-filename/correct-prompt-text ()
+  "Uses the exact prompt string \"Open? (C-g to quit): \"."
+  (ert-skip "Temporary skip test that fails on: (wrong-number-of-arguments #<subr identity> 2)")
+  (let (captured-prompt)
+    (cl-letf (((symbol-function 'read-file-name)
+               (lambda (prompt &rest _)
+                 (setq captured-prompt prompt)
+                 "/f.txt"))
+              ((symbol-function 'expand-file-name) #'identity))
+      (pel-prompt-for-filename)
+      (should (equal "Open? (C-g to quit): " captured-prompt)))))
+
+(ert-deftest test-pel-prompt-for-filename/nil-default-filename-arg ()
+  "Passes nil as DEFAULT_FILENAME (3rd arg) to `read-file-name'."
+  (ert-skip "Temporary skip test that fails on: (wrong-number-of-arguments #<subr identity> 2)")
+  (let (captured-default)
+    (cl-letf (((symbol-function 'read-file-name)
+               (lambda (_prompt _dir default &rest _)
+                 (setq captured-default default)
+                 "/f.txt"))
+              ((symbol-function 'expand-file-name) #'identity))
+      (pel-prompt-for-filename "hint.txt")
+      (should (null captured-default)))))
+
+;;; -------------------------------------------------------------------------
+;;; Tests for `pel-set-user-option'
+
+(defvar pel-test--dummy-opt nil
+  "Scratch variable for testing `pel-set-user-option'.")
+
+(ert-deftest test-pel-set-user-option/sets-global-value ()
+  "Sets USER-OPTION to the selected value globally."
+  (let ((pel-test--dummy-opt 'alpha)
+        (sel '((?a "Alpha" alpha) (?b "Beta" beta))))
+    (cl-letf (((symbol-function 'read-char-choice) (lambda (&rest _) ?b))
+              ((symbol-function 'message) #'ignore))
+      (pel-set-user-option "Choose: " 'pel-test--dummy-opt sel)
+      (should (eq 'beta pel-test--dummy-opt)))))
+
+(ert-deftest test-pel-set-user-option/sets-buffer-local-value ()
+  "Creates a buffer-local binding when LOCALLY is non-nil."
+  (let ((sel '((?a "Alpha" alpha) (?b "Beta" beta))))
+    (with-temp-buffer
+      (cl-letf (((symbol-function 'read-char-choice) (lambda (&rest _) ?a))
+                ((symbol-function 'message) #'ignore))
+        (pel-set-user-option "Choose: " 'pel-test--dummy-opt sel :locally)
+        (should (eq 'alpha pel-test--dummy-opt))
+        (should (local-variable-p 'pel-test--dummy-opt))))))
+
+(ert-deftest test-pel-set-user-option/messages-new-value ()
+  "Calls `message' with the variable name and its new description."
+  (let ((pel-test--dummy-opt 'alpha)
+        (sel '((?a "Alpha" alpha) (?b "Beta" beta)))
+        (msg nil))
+    (cl-letf (((symbol-function 'read-char-choice) (lambda (&rest _) ?b))
+              ((symbol-function 'message)
+               (lambda (fmt &rest args) (setq msg (apply #'format fmt args)))))
+      (pel-set-user-option "Choose: " 'pel-test--dummy-opt sel)
+      (should (string-match-p "Beta" msg))
+      (should (string-match-p "pel-test--dummy-opt" msg)))))
+
+;; ---------------------------------------------------------------------------
+;;; test-pel-prompt.el ends here

--- a/test/pel-prompt-test.el
+++ b/test/pel-prompt-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Wednesday, April 15 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-15 11:22:28 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-15 11:45:12 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -323,7 +323,6 @@
 
 (ert-deftest test-pel-prompt-purpose-for/empty-input-no-default-returns-empty ()
   "Returns empty string when input is empty and no default given."
-  (ert-skip "Temporary skip test that fails.")
   (pel-test--with-minibuffer-input ""
     (should (equal "" (pel-prompt-purpose-for "function")))))
 
@@ -594,4 +593,4 @@
       (should (string-match-p "pel-test--dummy-opt" msg)))))
 
 ;; ---------------------------------------------------------------------------
-;;; test-pel-prompt.el ends here
+;;; pel-prompt-test.el ends here

--- a/test/pel-prompt-test.el
+++ b/test/pel-prompt-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Wednesday, April 15 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-16 08:51:22 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-16 09:21:37 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -299,6 +299,27 @@
       (should (equal "apple"
                      (pel-prompt-select-read "Pick: " '("apple"
                                                         "banana")))))))
+
+(ert-deftest test-pel-prompt-select-read/non-nil-method-uses-ivy ()
+  "With non-nil `pel-prompt-read-method', delegates to `ivy-read'."
+  ;; The test support environments that uses or that does not use ivy.
+  ;; It mocks the presence of ivy if it is not present.
+  ;; It all cases it mock ivy-read to control what it returns.
+  (let ((pel-prompt-read-method 'ivy)
+        (added-ivy nil))
+    (unwind-protect
+        (progn
+          (unless (featurep 'ivy)
+            (provide 'ivy)
+            (setq added-ivy t))
+          (should (featurep 'ivy))
+          (cl-letf (((symbol-function 'ivy-read)
+                     (lambda (&rest _) "banana")))
+            (should (equal "banana"
+                           (pel-prompt-select-read "Pick: " '("apple"
+                                                              "banana"))))))
+      (when added-ivy
+        (setq features (delete 'ivy features))))))
 
 ;;; -------------------------------------------------------------------------
 ;;; Tests for `pel-prompt-purpose-for'

--- a/test/pel-prompt-test.el
+++ b/test/pel-prompt-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Wednesday, April 15 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-16 07:45:16 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-16 08:51:22 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -30,7 +30,7 @@
 ;;; --------------------------------------------------------------------------
 ;;; Dependencies:
 ;;
-;;
+
 (require 'pel-prompt)
 (require 'ert)
 (require 'cl-lib)
@@ -287,6 +287,18 @@
             ((symbol-function 'message) #'ignore))
     (should (equal "banana"
                    (pel-select-string-from "Pick: " '("apple" "banana"))))))
+
+;;; -------------------------------------------------------------------------
+;;; Tests for `pel-prompt-select-read'
+
+(ert-deftest test-pel-prompt-select-read/nil-method-returns-string ()
+  "With nil pel-prompt-read-method, returns selected string."
+  (cl-letf (((symbol-function 'read-char-choice) (lambda (&rest _) ?0))
+            ((symbol-function 'message) #'ignore))
+    (let ((pel-prompt-read-method nil))
+      (should (equal "apple"
+                     (pel-prompt-select-read "Pick: " '("apple"
+                                                        "banana")))))))
 
 ;;; -------------------------------------------------------------------------
 ;;; Tests for `pel-prompt-purpose-for'
@@ -547,6 +559,11 @@
               ((symbol-function 'expand-file-name) (lambda (f &optional _dir) f)))
       (pel-prompt-for-filename "hint.txt")
       (should (null captured-default)))))
+
+(ert-deftest test-pel-prompt-for-filename/rejects-non-string-non-nil ()
+  "Signals wrong-type-argument for a non-string, non-nil argument."
+  (should-error (pel-prompt-for-filename 42)
+                :type 'wrong-type-argument))
 
 ;;; -------------------------------------------------------------------------
 ;;; Tests for `pel-set-user-option'

--- a/test/pel-prompt-test.el
+++ b/test/pel-prompt-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Wednesday, April 15 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-15 17:07:34 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-16 07:45:16 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -470,7 +470,7 @@
                (lambda (_prompt dir &rest _)
                  (setq captured-dir dir)
                  "/some/file.txt"))
-              ((symbol-function 'expand-file-name) #'identity))
+              ((symbol-function 'expand-file-name) (lambda (f &optional _dir) f)))
       (pel-prompt-for-filename nil)
       (should (equal "" captured-dir)))))
 
@@ -481,7 +481,7 @@
                (lambda (_prompt dir &rest _)
                  (setq captured-dir dir)
                  "/some/file.txt"))
-              ((symbol-function 'expand-file-name) #'identity))
+              ((symbol-function 'expand-file-name) (lambda (f &optional _dir) f)))
       (pel-prompt-for-filename)
       (should (equal "" captured-dir)))))
 
@@ -492,7 +492,7 @@
                (lambda (_prompt dir &rest _)
                  (setq captured-dir dir)
                  "/some/file.txt"))
-              ((symbol-function 'expand-file-name) #'identity))
+              ((symbol-function 'expand-file-name) (lambda (f &optional _dir) f)))
       (pel-prompt-for-filename "myfile.txt")
       (should (equal "myfile.txt" captured-dir)))))
 
@@ -500,8 +500,7 @@
   "Returns the result of `expand-file-name' on `read-file-name' output."
   (cl-letf (((symbol-function 'read-file-name)
              (lambda (&rest _) "relative/path.txt"))
-            ((symbol-function 'expand-file-name)
-             (lambda (f) (concat "/root/" f))))
+            ((symbol-function 'expand-file-name) (lambda (f &optional _dir) (concat "/root/" f))))
     (should (equal "/root/relative/path.txt"
                    (pel-prompt-for-filename)))))
 
@@ -512,7 +511,7 @@
                (lambda (_prompt _dir _default mustmatch &rest _)
                  (setq captured-mustmatch mustmatch)
                  "/f.txt"))
-              ((symbol-function 'expand-file-name) #'identity))
+              ((symbol-function 'expand-file-name) (lambda (f &optional _dir) f)))
       (pel-prompt-for-filename)
       (should (eq 'confirm captured-mustmatch)))))
 
@@ -523,7 +522,7 @@
                (lambda (_prompt _dir _default _mustmatch _initial pred)
                  (setq captured-pred pred)
                  "/f.txt"))
-              ((symbol-function 'expand-file-name) #'identity))
+              ((symbol-function 'expand-file-name) (lambda (f &optional _dir) f)))
       (pel-prompt-for-filename)
       (should (eq 'file-exists-p captured-pred)))))
 
@@ -534,7 +533,7 @@
                (lambda (prompt &rest _)
                  (setq captured-prompt prompt)
                  "/f.txt"))
-              ((symbol-function 'expand-file-name) #'identity))
+              ((symbol-function 'expand-file-name) (lambda (f &optional _dir) f)))
       (pel-prompt-for-filename)
       (should (equal "Open? (C-g to quit): " captured-prompt)))))
 
@@ -545,7 +544,7 @@
                (lambda (_prompt _dir default &rest _)
                  (setq captured-default default)
                  "/f.txt"))
-              ((symbol-function 'expand-file-name) #'identity))
+              ((symbol-function 'expand-file-name) (lambda (f &optional _dir) f)))
       (pel-prompt-for-filename "hint.txt")
       (should (null captured-default)))))
 


### PR DESCRIPTION
- Consolidating the location of all prompt functions.
- Also making its only parameter optional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified wording around filename quoting/spacing and numeric window-direction behavior.

* **New Features**
  * Reworked filename prompt flow: interactive file-selection now validates and returns expanded paths; prompt wording/formatting improved.
  * Prompt choices accept refined input keys and stricter validation (invalid answers now raise an error).

* **Bug Fixes**
  * Restored consistent filename-prompt behavior across flows.

* **Tests**
  * Added comprehensive tests for prompting, selection, formatting, and filesystem prompting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->