### PR TITLE
Improve several functions by adding optional argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-2026 by Pierre Rouleau
 
 # Author: Pierre Rouleau <prouleau001@gmail.com>
-# Last Modified Time-stamp: <2026-04-16 10:18:41 EDT, updated by Pierre Rouleau>
+# Last Modified Time-stamp: <2026-04-16 22:12:36 EDT, updated by Pierre Rouleau>
 # Keywords: packaging, build-control
 
 # This file is part of the PEL package
@@ -936,6 +936,7 @@ test/pel-open-test.el.test-passed:              pel--base.elc pel-open.elc
 test/pel-mark-test.el.test-passed:              pel-mark.elc pel--base.elc
 test/pel-package-test.el.test-passed:           pel-package.elc pel--base.elc pel--options.elc
 test/pel-prompt-test.el.test-passed:            pel-prompt.elc
+test/pel-read-test.el.test-passed:              pel-read.elc
 test/pel-seq-test.el.test-passed:               pel-seq.elc
 test/pel-skel-c-test.el.test-passed:            pel--options.elc
 test/pel-skel-clisp-test.el.test-passed:        pel--options.elc

--- a/pel-read.el
+++ b/pel-read.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, May 25 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-17 09:00:01 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-17 09:33:31 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -75,7 +75,7 @@ See `bounds-of-thing-at-point' for a list of possible THING symbols."
                            (car bounds)
                            (cdr bounds)))
                ;; Emacs 26.1: bounds-of-thing-at-point for 'word 'sentence
-               ;; or 'paragraph can return ;; non-nil bounds covering only
+               ;; or 'paragraph can return non-nil bounds covering only
                ;; whitespace; reject that case.
                (or (not (memq thing '(word sentence paragraph)))
                    (string-match-p "\\w" text))))
@@ -165,8 +165,10 @@ If there is no character next, return an empty string."
 ;;  ==============================
 
 (defun pel-move-to-face (face limit)
-  "Move to the first char with specified FACE up to position LIMIT.
-Return point if char with FACE found, nil otherwise."
+  "Move to the first char with specified FACE, up to (but not including) LIMIT.
+If point is already on FACE, return point immediately without moving.
+Return the position of the first char with FACE, or nil if none is found
+before LIMIT."
   (while (and (not (eq face
                        (get-char-property (point) 'face)))
               (< (point) limit))
@@ -176,7 +178,7 @@ Return point if char with FACE found, nil otherwise."
     (point)))
 
 (defun pel-move-past-face (face limit)
-  "Move point past the contiguous region with FACE, up to position LIMIT.
+  "Move point past contiguous region with FACE, up to (but not including) LIMIT.
 If point is not on FACE, return point immediately.
 Return the new point position if a non-FACE char is reached before LIMIT,
 nil if the FACE region extends all the way to LIMIT."
@@ -195,7 +197,7 @@ Customize symbols are taken from Customize buffers *only*.
 They are identified by their `custom-variable-tag' face.
 The text may include space characters.
 The text must be on a single line.
-Return nil if there are no customize symbol on current line."
+Return nil if no customize symbol is present on the current line."
   ;; Identify the symbol by the face of text.
   ;; Start from the beginning o the line.
   (save-excursion

--- a/pel-read.el
+++ b/pel-read.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, May 25 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-17 14:21:39 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-17 15:20:37 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -44,9 +44,9 @@
 ;;
 ;;  Read customize symbol at point
 ;;  - `pel-customize-symbol-at-line'
-;;    - `pel-move-to-face'
+;;    - `pel--move-to-face'
 ;;      - `pel-read--face-at-point-p'
-;;    - `pel-move-past-face'
+;;    - `pel--move-past-face'
 ;;      . `pel-read--face-at-point-p'
 
 ;;; --------------------------------------------------------------------------
@@ -173,7 +173,7 @@ point and the end of the buffer. "
         (memq face f)
       (eq face f))))
 
-(defun pel-move-to-face (face limit)
+(defun pel--move-to-face (face limit)
   "Move to the first char with specified FACE, up to (but not including) LIMIT.
 If point is already on FACE, return point immediately without moving.
 Return the position of the first char with FACE, or nil if none is found
@@ -185,11 +185,13 @@ before LIMIT."
       nil
     (point)))
 
-(defun pel-move-past-face (face limit)
+(defun pel--move-past-face (face limit)
   "Move point past contiguous region with FACE, up to (but not including) LIMIT.
 If point is not on FACE, return point immediately.
 Return the new point position if a non-FACE char is reached before LIMIT,
-nil if the FACE region extends all the way to LIMIT."
+nil if the FACE region extends all the way to LIMIT.
+If point is not on FACE but equals LIMIT on entry, nil is returned (same
+as when the face region fills the buffer up to limit)."
   (while (and (pel-read--face-at-point-p face)
               (< (point) limit))
     (forward-char 1))
@@ -215,9 +217,9 @@ Return nil if no customize symbol is present on the current line."
                 (point))))
       ;; move to the beginning of line, unconstrained by fields
       (forward-line 0)
-      (setq p1 (pel-move-to-face 'custom-variable-tag pe))
+      (setq p1 (pel--move-to-face 'custom-variable-tag pe))
       (when p1
-        (setq p2 (pel-move-past-face 'custom-variable-tag pe))
+        (setq p2 (pel--move-past-face 'custom-variable-tag pe))
         (when p2
           (buffer-substring-no-properties p1 p2))))))
 

--- a/pel-read.el
+++ b/pel-read.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, May 25 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-17 10:53:55 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-17 11:15:44 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -179,7 +179,7 @@ before LIMIT."
   (while (and (not (pel-read--face-at-point-p face))
               (< (point) limit))
     (forward-char 1))
-  (if (eq (point) limit)
+  (if (= (point) limit)
       nil
     (point)))
 
@@ -204,7 +204,7 @@ The text may include space characters.
 The text must be on a single line.
 Return nil if no customize symbol is present on the current line."
   ;; Identify the symbol by the face of text.
-  ;; Start from the beginning o the line.
+  ;; Start from the beginning of the line.
   (save-excursion
     (let (p1                            ; point of first char
           p2                            ; point of last char

--- a/pel-read.el
+++ b/pel-read.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, May 25 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-17 11:15:44 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-17 11:33:03 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -95,7 +95,7 @@ See `bounds-of-thing-at-point' for a list of possible THING symbols."
   "Return sentence at point, move to next sentence unless DONT-MOVE is non-nil."
   ;; pel-thing-at-point leaves point just after the period at the end of the
   ;; sentence.  pel-forward-word-start moves point to the beginning of the
-  ;; next sentence.
+  ;; next word, which is the beginning of the next sentence.
   (let ((text (pel-thing-at-point 'sentence)))
     (unless dont-move
       (ignore-errors
@@ -107,7 +107,7 @@ See `bounds-of-thing-at-point' for a list of possible THING symbols."
   "Return paragraph at point, move to next paragraph unless DONT-MOVE is non-nil."
   ;; pel-thing-at-point leaves point just after the period at the end of the
   ;; paragraph.  pel-forward-word-start moves point to the beginning of the
-  ;; next paragraph.
+  ;; next word, which is the beginning of the next paragraph.
   (let ((text (pel-thing-at-point 'paragraph)))
     (unless dont-move
       (ignore-errors
@@ -191,7 +191,7 @@ nil if the FACE region extends all the way to LIMIT."
   (while (and (pel-read--face-at-point-p face)
               (< (point) limit))
     (forward-char 1))
-  (if (eq (point) limit)
+  (if (= (point) limit)
       nil
     (point)))
 

--- a/pel-read.el
+++ b/pel-read.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, May 25 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-16 22:31:08 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-17 07:27:03 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -27,6 +27,9 @@
 ;;
 ;; Utility functions that read various text elements from current buffer at
 ;; point.
+;;
+;; The following call hierarchy uses '-' for functions and '.' when repeating
+;; a function also called that has already been represented in the hierarchy.
 ;;
 ;;  Read "thing" at point
 ;;  - `pel-word-at-point'
@@ -81,28 +84,34 @@ See `bounds-of-thing-at-point' for a list of possible THING symbols."
       (user-error "No %s at point" thing))))
 
 ;;-pel-autoload
-(defun pel-word-at-point (&optional stay)
-  "Return word at point, move to next word unless STAY is non-nil."
+(defun pel-word-at-point (&optional dont-move)
+  "Return word at point, move to next word unless DONT-MOVE is non-nil."
   (let ((text (pel-thing-at-point 'word)))
-    (unless stay
+    (unless dont-move
       (ignore-errors
         (pel-forward-word-start)))
     text))
 
 ;;-pel-autoload
-(defun pel-sentence-at-point (&optional stay)
-  "Return sentence at point, move to next sentence unless STAY is non-nil."
+(defun pel-sentence-at-point (&optional dont-move)
+  "Return sentence at point, move to next sentence unless DONT-MOVE is non-nil."
+  ;; pel-thing-at-point leaves point just after the period at the end of the
+  ;; sentence.  pel-forward-word-start moves point to the beginning of the
+  ;; next sentence.
   (let ((text (pel-thing-at-point 'sentence)))
-    (unless stay
+    (unless dont-move
       (ignore-errors
         (pel-forward-word-start)))
     text))
 
 ;;-pel-autoload
-(defun pel-paragraph-at-point (&optional stay)
-  "Return paragraph at point, move to next paragraph unless STAY is non-nil."
+(defun pel-paragraph-at-point (&optional dont-move)
+  "Return paragraph at point, move to next paragraph unless DONT-MOVE is non-nil."
+  ;; pel-thing-at-point leaves point just after the period at the end of the
+  ;; paragraph.  pel-forward-word-start moves point to the beginning of the
+  ;; next paragraph.
   (let ((text (pel-thing-at-point 'paragraph)))
-    (unless stay
+    (unless dont-move
       (ignore-errors
         (pel-forward-word-start)))
     text))
@@ -153,7 +162,7 @@ spaces even when point is located between the delimiters."
 ;;  ==============================
 
 (defun pel-move-to-face (face limit)
-  "Move to the first char with specified FACE up to LIMIT point.
+  "Move to the first char with specified FACE up to position LIMIT.
 Return point if char with FACE found, nil otherwise."
   (while (and (not (eq face
                        (get-char-property (point) 'face)))
@@ -164,8 +173,10 @@ Return point if char with FACE found, nil otherwise."
     (point)))
 
 (defun pel-move-past-face (face limit)
-  "Move to the first char that does not have specified FACE up to LIMIT point.
-Return point if char with FACE found, nil otherwise."
+  "Move point past the contiguous region with FACE, up to position LIMIT.
+If point is not on FACE, return point immediately.
+Return the new point position if a non-FACE char is reached before LIMIT,
+nil if the FACE region extends all the way to LIMIT."
   (while (and (eq face
                   (get-char-property (point) 'face))
               (< (point) limit))

--- a/pel-read.el
+++ b/pel-read.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, May 25 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-17 07:27:03 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-17 09:00:01 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -74,9 +74,10 @@ See `bounds-of-thing-at-point' for a list of possible THING symbols."
                (setq text (buffer-substring-no-properties
                            (car bounds)
                            (cdr bounds)))
-               ;; Emacs 26.1: bounds-of-thing-at-point 'word can return
-               ;; non-nil bounds covering only whitespace; reject that case.
-               (or (not (eq thing 'word))
+               ;; Emacs 26.1: bounds-of-thing-at-point for 'word 'sentence
+               ;; or 'paragraph can return ;; non-nil bounds covering only
+               ;; whitespace; reject that case.
+               (or (not (memq thing '(word sentence paragraph)))
                    (string-match-p "\\w" text))))
         (progn
           (goto-char (cdr bounds))
@@ -131,7 +132,9 @@ The DELIMITERS string must NOT include a space:
 
 If ALLOW-SPACE is non-nil, then the space character is never included in
 the delimiters so it becomes possible to capture a delimited string with
-spaces even when point is located between the delimiters."
+spaces even when point is located between the delimiters.
+
+If there is no character next, return an empty string."
   (save-excursion
     (let ((next-char (char-after)))
       (if next-char

--- a/pel-read.el
+++ b/pel-read.el
@@ -2,12 +2,12 @@
 
 ;; Created   : Tuesday, May 25 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2025-01-15 11:45:56 EST, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-16 17:00:49 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
 
-;; Copyright (C) 2020, 2021, 2022, 2025  Pierre Rouleau
+;; Copyright (C) 2020, 2021, 2022, 2025, 2026  Pierre Rouleau
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -25,23 +25,37 @@
 ;;; --------------------------------------------------------------------------
 ;;; Commentary:
 ;;
-;; Utility functions that read text from current buffer at point.
+;; Utility functions that read various text elements from current buffer at
+;; point.
 ;;
+;;  Read "thing" at point
 ;;  - `pel-word-at-point'
-;;  - `pel-sentence-at-point'
-;;  - `pel-paragraph-at-point'
 ;;    - `pel-thing-at-point'
+;;  - `pel-sentence-at-point'
+;;    . `pel-thing-at-point'
+;;  - `pel-paragraph-at-point'
+;;    . `pel-thing-at-point'
+;;
+;;  Read string at point
 ;;  - `pel-string-at-point'
+;;
+;;  Read customize symbol at point
+;;  - `pel-customize-symbol-at-line'
+;;    - `pel-move-to-face'
+;;    - `pel-move-past-face'
 ;;
 
 ;;; --------------------------------------------------------------------------
 ;;; Dependencies:
 ;;
-(require 'pel-navigate)   ; use: pel-forward-word-start
+(require 'pel-navigate)   ; use: `pel-forward-word-start'
 
 ;;; --------------------------------------------------------------------------
 ;;; Code:
 ;;
+
+;;* Read "thing" at point
+;;  =====================
 
 (defun pel-thing-at-point (thing)
   "Read and return the string of THING at point.
@@ -59,35 +73,39 @@ See `bounds-of-thing-at-point' for a list of possible THING symbols."
                       (cdr bounds)))
           (goto-char (cdr bounds))
           text)
-      (error "No %s at point" thing))))
+      (user-error "No %s at point" thing))))
+
 
 ;;-pel-autoload
-(defun pel-word-at-point ()
-  "Read and return word at point, moving to next word."
+(defun pel-word-at-point (&optional dont-move)
+  "Return word at point, move to next word unless DONT-MOVE is set."
   (let ((text (pel-thing-at-point 'word)))
-    (ignore-errors
-      (pel-forward-word-start))
+    (unless dont-move
+      (ignore-errors
+        (pel-forward-word-start)))
     text))
 
 ;;-pel-autoload
-(defun pel-sentence-at-point ()
-  "Read and return sentence at point, moving to next sentence."
+(defun pel-sentence-at-point (&optional dont-move)
+  "Return sentence at point, move to next sentence unless DONT-MOVE is set."
   (let ((text (pel-thing-at-point 'sentence)))
-    (ignore-errors
-      (pel-forward-word-start))
+    (unless dont-move
+      (ignore-errors
+        (pel-forward-word-start)))
     text))
 
 ;;-pel-autoload
-(defun pel-paragraph-at-point ()
-  "Read and return paragraph at point, moving to next paragraph."
+(defun pel-paragraph-at-point (&optional dont-move)
+  "Return paragraph at point, move to next paragraph unless DONT-MOVE is set."
   (let ((text (pel-thing-at-point 'paragraph)))
-    (ignore-errors
-      (pel-forward-word-start))
+    (unless dont-move
+      (ignore-errors
+        (pel-forward-word-start)))
     text))
 
 ;; ---------------------------------------------------------------------------
-;; Read string at point
-;; --------------------
+;;* Read string at point
+;;  ====================
 
 (defun pel-string-at-point (delimiters &optional allow-space)
   "Return the string at point delimited by DELIMITERS string.
@@ -98,8 +116,8 @@ The DELIMITERS string must NOT include a space:
 - When point is located at a delimiter, space is not added as a delimiter
   to allow space to be included in the extracted string.
 
-If ALLOW-SPACE is non-nil, then the space character is never included
-in the delimiters so it becomes possible to capture a delimited string with
+If ALLOW-SPACE is non-nil, then the space character is never included in
+the delimiters so it becomes possible to capture a delimited string with
 spaces even when point is located between the delimiters."
   (save-excursion
     (let ((next-char (char-after)))
@@ -127,8 +145,8 @@ spaces even when point is located between the delimiters."
         ""))))
 
 ;; ---------------------------------------------------------------------------
-;; Read Customize Symbol at point
-;; ------------------------------
+;;* Read customize symbol at point
+;;  ==============================
 
 (defun pel-move-to-face (face limit)
   "Move to the first char with specified FACE up to LIMIT point.
@@ -158,12 +176,13 @@ Return point if char with FACE found, nil otherwise."
 Customize symbols are taken from Customize buffers *only*.
 They are identified by their `custom-variable-tag' face.
 The text may include space characters.
-The text must be on a single line."
+The text must be on a single line.
+Return nil if there are no customize symbol on current line."
   ;; Identify the symbol by the face of text.
   ;; Start from the beginning o the line.
   (save-excursion
-    (let (p1     ; point of first char
-          p2     ; point of last char
+    (let (p1                            ; point of first char
+          p2                            ; point of last char
           (pe (progn
                 (move-end-of-line 1)
                 (point))))

--- a/pel-read.el
+++ b/pel-read.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, May 25 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-16 17:00:49 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-16 22:11:35 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -77,28 +77,28 @@ See `bounds-of-thing-at-point' for a list of possible THING symbols."
 
 
 ;;-pel-autoload
-(defun pel-word-at-point (&optional dont-move)
-  "Return word at point, move to next word unless DONT-MOVE is set."
+(defun pel-word-at-point (&optional stay)
+  "Return word at point, move to next word unless STAY is non-nil."
   (let ((text (pel-thing-at-point 'word)))
-    (unless dont-move
+    (unless stay
       (ignore-errors
         (pel-forward-word-start)))
     text))
 
 ;;-pel-autoload
-(defun pel-sentence-at-point (&optional dont-move)
-  "Return sentence at point, move to next sentence unless DONT-MOVE is set."
+(defun pel-sentence-at-point (&optional stay)
+  "Return sentence at point, move to next sentence unless STAY is non-nil."
   (let ((text (pel-thing-at-point 'sentence)))
-    (unless dont-move
+    (unless stay
       (ignore-errors
         (pel-forward-word-start)))
     text))
 
 ;;-pel-autoload
-(defun pel-paragraph-at-point (&optional dont-move)
-  "Return paragraph at point, move to next paragraph unless DONT-MOVE is set."
+(defun pel-paragraph-at-point (&optional stay)
+  "Return paragraph at point, move to next paragraph unless STAY is non-nil."
   (let ((text (pel-thing-at-point 'paragraph)))
-    (unless dont-move
+    (unless stay
       (ignore-errors
         (pel-forward-word-start)))
     text))

--- a/pel-read.el
+++ b/pel-read.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, May 25 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-16 22:11:35 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-16 22:31:08 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -66,15 +66,19 @@ See `bounds-of-thing-at-point' for a list of possible THING symbols."
     (user-error "Failed loading thingatpt!"))
   (let ((bounds (bounds-of-thing-at-point thing))
         text)
-    (if bounds
+    (if (and bounds
+             (progn
+               (setq text (buffer-substring-no-properties
+                           (car bounds)
+                           (cdr bounds)))
+               ;; Emacs 26.1: bounds-of-thing-at-point 'word can return
+               ;; non-nil bounds covering only whitespace; reject that case.
+               (or (not (eq thing 'word))
+                   (string-match-p "\\w" text))))
         (progn
-          (setq text (buffer-substring-no-properties
-                      (car bounds)
-                      (cdr bounds)))
           (goto-char (cdr bounds))
           text)
       (user-error "No %s at point" thing))))
-
 
 ;;-pel-autoload
 (defun pel-word-at-point (&optional stay)

--- a/pel-read.el
+++ b/pel-read.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, May 25 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-17 10:02:10 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-17 10:53:55 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -45,14 +45,15 @@
 ;;  Read customize symbol at point
 ;;  - `pel-customize-symbol-at-line'
 ;;    - `pel-move-to-face'
+;;      - `pel-read--face-at-point-p'
 ;;    - `pel-move-past-face'
-;;
+;;      . `pel-read--face-at-point-p'
 
 ;;; --------------------------------------------------------------------------
 ;;; Dependencies:
 ;;
 (require 'pel-navigate)   ; use: `pel-forward-word-start'
-
+(require 'thingatpt)      ; use: `bounds-of-thing-at-point'
 ;;; --------------------------------------------------------------------------
 ;;; Code:
 ;;
@@ -63,10 +64,6 @@
 (defun pel-thing-at-point (thing)
   "Read and return the string of THING at point.
 See `bounds-of-thing-at-point' for a list of possible THING symbols."
-  ;; thingatpt: use: bounds-of-thing-at-point
-  (unless (and (require 'thingatpt nil :noerror)
-               (fboundp 'bounds-of-thing-at-point))
-    (user-error "Failed loading thingatpt!"))
   (let ((bounds (bounds-of-thing-at-point thing))
         text)
     (if (and bounds
@@ -128,7 +125,10 @@ The DELIMITERS string must NOT include a space:
 - If point is currently NOT located at one of the DELIMITERS characters
   then the space character is automatically added to the DELIMITERS.
 - When point is located at a delimiter, space is not added as a delimiter
-  to allow space to be included in the extracted string.
+  to allow space to be included in the extracted string enclosed within the
+  delimiters.
+
+Note that any of the DELIMITERS can be used as a start or end delimiter.
 
 If ALLOW-SPACE is non-nil, then the space character is never included in
 the delimiters so it becomes possible to capture a delimited string with
@@ -164,13 +164,19 @@ If there is no character next, return an empty string."
 ;;* Read customize symbol at point
 ;;  ==============================
 
+(defun pel-read--face-at-point-p (face)
+  "Return non-nil if FACE applies at point (handles both symbol and list)."
+  (let ((f (get-char-property (point) 'face)))
+    (if (listp f)
+        (memq face f)
+      (eq face f))))
+
 (defun pel-move-to-face (face limit)
   "Move to the first char with specified FACE, up to (but not including) LIMIT.
 If point is already on FACE, return point immediately without moving.
 Return the position of the first char with FACE, or nil if none is found
 before LIMIT."
-  (while (and (not (eq face
-                       (get-char-property (point) 'face)))
+  (while (and (not (pel-read--face-at-point-p face))
               (< (point) limit))
     (forward-char 1))
   (if (eq (point) limit)
@@ -182,8 +188,7 @@ before LIMIT."
 If point is not on FACE, return point immediately.
 Return the new point position if a non-FACE char is reached before LIMIT,
 nil if the FACE region extends all the way to LIMIT."
-  (while (and (eq face
-                  (get-char-property (point) 'face))
+  (while (and (pel-read--face-at-point-p face)
               (< (point) limit))
     (forward-char 1))
   (if (eq (point) limit)

--- a/pel-read.el
+++ b/pel-read.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, May 25 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-17 11:33:03 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-17 14:21:39 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -134,7 +134,9 @@ If ALLOW-SPACE is non-nil, then the space character is never included in
 the delimiters so it becomes possible to capture a delimited string with
 spaces even when point is located between the delimiters.
 
-If there is no character next, return an empty string."
+If there is no character next, return an empty string.
+If there is no delimiter found before end of buffer return the text between
+point and the end of the buffer. "
   (save-excursion
     (let ((next-char (char-after)))
       (if next-char

--- a/pel-read.el
+++ b/pel-read.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, May 25 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-17 09:33:31 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-17 10:02:10 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -74,7 +74,7 @@ See `bounds-of-thing-at-point' for a list of possible THING symbols."
                (setq text (buffer-substring-no-properties
                            (car bounds)
                            (cdr bounds)))
-               ;; Emacs 26.1: bounds-of-thing-at-point for 'word 'sentence
+               ;; Emacs 26.1: bounds-of-thing-at-point for 'word, 'sentence
                ;; or 'paragraph can return non-nil bounds covering only
                ;; whitespace; reject that case.
                (or (not (memq thing '(word sentence paragraph)))

--- a/test/pel-read-test.el
+++ b/test/pel-read-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, April 16 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-17 10:38:06 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-17 11:19:22 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -114,7 +114,7 @@
         (pel-word-at-point)
         (should called)))))
 
-(ert-deftest pel-read/sentence-at-point/no-word-signals-user-error ()
+(ert-deftest pel-read/word-at-point/no-word-signals-user-error ()
   "Signals `user-error' in an empty buffer (no word)."
   (with-temp-buffer
     (should-error (pel-word-at-point t) :type 'user-error)))

--- a/test/pel-read-test.el
+++ b/test/pel-read-test.el
@@ -1,0 +1,346 @@
+;;; pel-read-test.el --- Test pel-read.el  -*- lexical-binding: t; -*-
+
+;; Created   : Thursday, April 16 2026.
+;; Author    : Pierre Rouleau <prouleau001@gmail.com>
+;; Time-stamp: <2026-04-16 22:08:40 EDT, updated by Pierre Rouleau>
+
+;; This file is part of the PEL package.
+;; This file is not part of GNU Emacs.
+
+;; Copyright (C) 2026  Pierre Rouleau
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; --------------------------------------------------------------------------
+;;; Commentary:
+;;
+;;
+
+;;; --------------------------------------------------------------------------
+;;; Dependencies:
+
+(require 'pel-read)
+(require 'ert)
+(require 'cl-lib)   ; use: `cl-letf'
+
+
+;;; --------------------------------------------------------------------------
+;;; Code:
+;;
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+
+(defmacro pel-read-test--with-buffer (content &rest body)
+  "Execute BODY in a temp buffer pre-filled with CONTENT, point at start."
+  (declare (indent 1))
+  `(with-temp-buffer
+     (insert ,content)
+     (goto-char (point-min))
+     ,@body))
+
+;; ---------------------------------------------------------------------------
+;; pel-thing-at-point
+
+(ert-deftest pel-read/thing-at-point/returns-word ()
+  "Returns the word text when point is on a word."
+  (pel-read-test--with-buffer "hello world"
+    (should (string= "hello" (pel-thing-at-point 'word)))))
+
+(ert-deftest pel-read/thing-at-point/moves-to-end-of-thing ()
+  "Moves point to the end of the matched thing (cdr of bounds)."
+  (pel-read-test--with-buffer "hello world"
+    (pel-thing-at-point 'word)
+    (should (= (point) 6))))          ; after "hello" (1-based, 6 = past 'o')
+
+(ert-deftest pel-read/thing-at-point/signals-user-error-when-absent ()
+  "Signals `user-error' (not `error') when no thing is at point."
+  (pel-read-test--with-buffer "   "
+    (should-error (pel-thing-at-point 'word) :type 'user-error)))
+
+(ert-deftest pel-read/thing-at-point/returns-sentence ()
+  "Returns the sentence text at point."
+  (pel-read-test--with-buffer "Hello world.  Goodbye."
+    (should (string= "Hello world." (pel-thing-at-point 'sentence)))))
+
+(ert-deftest pel-read/thing-at-point/empty-buffer-signals-user-error ()
+  "Signals `user-error' in an empty buffer."
+  (with-temp-buffer
+    (should-error (pel-thing-at-point 'word) :type 'user-error)))
+
+;; ---------------------------------------------------------------------------
+;; pel-word-at-point
+
+(ert-deftest pel-read/word-at-point/returns-word ()
+  "Returns the word string at point."
+  (pel-read-test--with-buffer "emacs lisp"
+    (should (string= "emacs" (pel-word-at-point t)))))
+
+(ert-deftest pel-read/word-at-point/dont-move-suppresses-forward-call ()
+  "When DONT-MOVE is non-nil, pel-forward-word-start is NOT called."
+  (pel-read-test--with-buffer "emacs lisp"
+    (let ((called nil))
+      (cl-letf (((symbol-function 'pel-forward-word-start)
+                 (lambda () (setq called t))))
+        (pel-word-at-point t)
+        (should-not called)))))
+
+(ert-deftest pel-read/word-at-point/no-dont-move-calls-forward ()
+  "When DONT-MOVE is nil, pel-forward-word-start IS called."
+  (pel-read-test--with-buffer "emacs lisp"
+    (let ((called nil))
+      (cl-letf (((symbol-function 'pel-forward-word-start)
+                 (lambda () (setq called t))))
+        (pel-word-at-point)
+        (should called)))))
+
+(ert-deftest pel-read/word-at-point/no-word-signals-user-error ()
+  "Signals `user-error' when no word is at point."
+  (pel-read-test--with-buffer "   "
+    (should-error (pel-word-at-point t) :type 'user-error)))
+
+(ert-deftest pel-read/word-at-point/return-type-is-string ()
+  "Return value is always a string."
+  (pel-read-test--with-buffer "test"
+    (should (stringp (pel-word-at-point t)))))
+
+;; ---------------------------------------------------------------------------
+;; pel-sentence-at-point
+
+(ert-deftest pel-read/sentence-at-point/returns-sentence ()
+  "Returns the sentence text at point."
+  (pel-read-test--with-buffer "Hello world.  Goodbye."
+    (should (string= "Hello world." (pel-sentence-at-point t)))))
+
+(ert-deftest pel-read/sentence-at-point/dont-move-suppresses-forward-call ()
+  "When DONT-MOVE is non-nil, pel-forward-word-start is NOT called."
+  (pel-read-test--with-buffer "Hello world.  Goodbye."
+    (let ((called nil))
+      (cl-letf (((symbol-function 'pel-forward-word-start)
+                 (lambda () (setq called t))))
+        (pel-sentence-at-point t)
+        (should-not called)))))
+
+(ert-deftest pel-read/sentence-at-point/no-dont-move-calls-forward ()
+  "When DONT-MOVE is nil, pel-forward-word-start IS called."
+  (pel-read-test--with-buffer "Hello world.  Goodbye."
+    (let ((called nil))
+      (cl-letf (((symbol-function 'pel-forward-word-start)
+                 (lambda () (setq called t))))
+        (pel-sentence-at-point)
+        (should called)))))
+
+(ert-deftest pel-read/sentence-at-point/no-sentence-signals-user-error ()
+  "Signals `user-error' in an empty buffer (no sentence)."
+  (with-temp-buffer
+    (should-error (pel-sentence-at-point t) :type 'user-error)))
+
+;; ---------------------------------------------------------------------------
+;; pel-paragraph-at-point
+
+(ert-deftest pel-read/paragraph-at-point/returns-paragraph ()
+  "Returns a string containing paragraph text at point."
+  (pel-read-test--with-buffer "First paragraph.\n\nSecond paragraph."
+    (let ((para (pel-paragraph-at-point t)))
+      (should (stringp para))
+      (should (string-match-p "First paragraph" para)))))
+
+(ert-deftest pel-read/paragraph-at-point/dont-move-suppresses-forward-call ()
+  "When DONT-MOVE is non-nil, pel-forward-word-start is NOT called."
+  (pel-read-test--with-buffer "First paragraph.\n\nSecond paragraph."
+    (let ((called nil))
+      (cl-letf (((symbol-function 'pel-forward-word-start)
+                 (lambda () (setq called t))))
+        (pel-paragraph-at-point t)
+        (should-not called)))))
+
+(ert-deftest pel-read/paragraph-at-point/no-dont-move-calls-forward ()
+  "When DONT-MOVE is nil, pel-forward-word-start IS called."
+  (pel-read-test--with-buffer "First paragraph.\n\nSecond paragraph."
+    (let ((called nil))
+      (cl-letf (((symbol-function 'pel-forward-word-start)
+                 (lambda () (setq called t))))
+        (pel-paragraph-at-point)
+        (should called)))))
+
+(ert-deftest pel-read/paragraph-at-point/no-paragraph-signals-user-error ()
+  "Signals `user-error' when no paragraph exists at point."
+  (with-temp-buffer
+    (should-error (pel-paragraph-at-point t) :type 'user-error)))
+
+;; ---------------------------------------------------------------------------
+;; pel-string-at-point
+
+(ert-deftest pel-read/string-at-point/point-inside-quoted-string ()
+  "Extracts the substring between quote delimiters when point is inside."
+  (pel-read-test--with-buffer "\"hello\""
+                              (goto-char 2) ; inside the quotes
+                              (should (string= "hello" (pel-string-at-point "\"")))))
+
+(ert-deftest pel-read/string-at-point/point-at-opening-delimiter ()
+  "Extracts substring correctly when point is at the opening delimiter."
+  (pel-read-test--with-buffer "\"hello\""
+    (goto-char 1)                         ; at opening quote
+    (should (string= "hello" (pel-string-at-point "\"")))))
+
+(ert-deftest pel-read/string-at-point/empty-buffer-returns-empty-string ()
+  "Returns empty string when buffer is empty (no next char)."
+  (with-temp-buffer
+    (should (string= "" (pel-string-at-point "\"")))))
+
+(ert-deftest pel-read/string-at-point/space-auto-added-as-delimiter ()
+  "Space is auto-added as delimiter when point is not at a delimiter char."
+  (pel-read-test--with-buffer "hello world foo"
+    (goto-char 3)                         ; inside "hello", not at delimiter
+    (should (string= "hello" (pel-string-at-point "\"")))))
+
+(ert-deftest pel-read/string-at-point/allow-space-includes-spaces ()
+  "With ALLOW-SPACE non-nil, spaces are included in the extracted string."
+  (pel-read-test--with-buffer "\"hello world\""
+    (goto-char 2)
+    (should (string= "hello world" (pel-string-at-point "\"" t)))))
+
+(ert-deftest pel-read/string-at-point/multiple-delimiter-chars ()
+  "Supports a multi-character DELIMITERS string."
+  (pel-read-test--with-buffer "(hello)"
+    (goto-char 2)                         ; inside parens
+    (should (string= "hello" (pel-string-at-point "()")))))
+
+(ert-deftest pel-read/string-at-point/does-not-move-point ()
+  "Does not move point (wrapped in save-excursion)."
+  (pel-read-test--with-buffer "\"hello\""
+    (goto-char 2)
+    (let ((pos (point)))
+      (pel-string-at-point "\"")
+      (should (= pos (point))))))
+
+;; ---------------------------------------------------------------------------
+;; pel-move-to-face
+
+(ert-deftest pel-read/move-to-face/finds-face-and-returns-point ()
+  "Moves to the first char with the given face and returns that position."
+  (with-temp-buffer
+    (insert "abcdef")
+    ;; chars at positions 3-5 ("cde") get the test face
+    (put-text-property 3 6 'face 'pel-test-face)
+    (goto-char (point-min))
+    (let ((result (pel-move-to-face 'pel-test-face (point-max))))
+      (should (= result 3))
+      (should (= (point) 3)))))
+
+(ert-deftest pel-read/move-to-face/returns-nil-when-face-absent ()
+  "Returns nil when the face is never found before limit."
+  (with-temp-buffer
+    (insert "abcdef")
+    (goto-char (point-min))
+    (should (null (pel-move-to-face 'nonexistent-face (point-max))))))
+
+(ert-deftest pel-read/move-to-face/respects-limit ()
+  "Does not cross the limit even if the face appears beyond it."
+  (with-temp-buffer
+    (insert "abcdef")
+    (put-text-property 5 7 'face 'pel-test-face)  ; "ef" has the face
+    (goto-char (point-min))
+    ;; limit is 4, face starts at 5 → not found
+    (should (null (pel-move-to-face 'pel-test-face 4)))))
+
+;; ---------------------------------------------------------------------------
+;; pel-move-past-face
+
+(ert-deftest pel-read/move-past-face/advances-past-face-region ()
+  "Moves point past the contiguous region carrying the specified face."
+  (with-temp-buffer
+    (insert "abcdef")
+    ;; positions 1-4 ("abcd") have the face
+    (put-text-property 1 5 'face 'pel-test-face)
+    (goto-char (point-min))
+    (let ((result (pel-move-past-face 'pel-test-face (point-max))))
+      (should (= result 5))
+      (should (= (point) 5)))))
+
+(ert-deftest pel-read/move-past-face/returns-nil-when-face-fills-to-limit ()
+  "Returns nil when the face region extends all the way to limit."
+  (with-temp-buffer
+    (insert "abcdef")
+    (put-text-property 1 7 'face 'pel-test-face)  ; entire content
+    (goto-char (point-min))
+    (should (null (pel-move-past-face 'pel-test-face (point-max))))))
+
+(ert-deftest pel-read/move-past-face/no-face-at-start-returns-current-point ()
+  "Returns current point immediately when point is not on the given face."
+  (with-temp-buffer
+    (insert "abcdef")
+    (put-text-property 3 6 'face 'pel-test-face)  ; only "cde"
+    (goto-char (point-min))                        ; position 1 — no face here
+    (let ((result (pel-move-past-face 'pel-test-face (point-max))))
+      (should (= result 1)))))
+
+;; ---------------------------------------------------------------------------
+;; pel-customize-symbol-at-line
+
+(ert-deftest pel-read/customize-symbol-at-line/returns-nil-without-face ()
+  "Returns nil when no custom-variable-tag face is present on the line."
+  (with-temp-buffer
+    (insert "Some plain text line")
+    (goto-char (point-min))
+    (should (null (pel-customize-symbol-at-line)))))
+
+(ert-deftest pel-read/customize-symbol-at-line/returns-tagged-text ()
+  "Returns the text carrying the custom-variable-tag face."
+  (with-temp-buffer
+    (insert "   My Symbol   rest of line")
+    ;;       123456789012345
+    ;; "My Symbol" occupies positions 4-12 (9 chars, exclusive end = 13)
+    (put-text-property 4 13 'face 'custom-variable-tag)
+    (goto-char (point-min))
+    (should (string= "My Symbol" (pel-customize-symbol-at-line)))))
+
+(ert-deftest pel-read/customize-symbol-at-line/does-not-move-point ()
+  "Does not move point (wrapped in save-excursion)."
+  (with-temp-buffer
+    (insert "   My Symbol   rest of line")
+    (put-text-property 4 13 'face 'custom-variable-tag)
+    (goto-char (point-min))
+    (let ((pos (point)))
+      (pel-customize-symbol-at-line)
+      (should (= pos (point))))))
+
+(ert-deftest pel-read/customize-symbol-at-line/ignores-other-lines ()
+  "Does not see a tagged symbol that is on a different line."
+  (with-temp-buffer
+    (insert "plain line\nTagged Symbol more text")
+    ;;                    ^pos 12
+    (put-text-property 12 25 'face 'custom-variable-tag)
+    (goto-char (point-min))            ; still on line 1
+    (should (null (pel-customize-symbol-at-line)))))
+
+(ert-deftest pel-read/customize-symbol-at-line/empty-buffer-returns-nil ()
+  "Returns nil in an empty buffer."
+  (with-temp-buffer
+    (should (null (pel-customize-symbol-at-line)))))
+
+(ert-deftest pel-read/customize-symbol-at-line/symbol-with-spaces ()
+  "Correctly extracts a symbol whose text contains spaces."
+  (with-temp-buffer
+    (insert "Foo Bar Baz end")
+    ;;       123456789012
+    ;; "Foo Bar Baz" at 1-11 (exclusive end 12)
+    (put-text-property 1 12 'face 'custom-variable-tag)
+    (goto-char (point-min))
+    (should (string= "Foo Bar Baz" (pel-customize-symbol-at-line)))))
+
+;;; --------------------------------------------------------------------------
+(provide 'pel-read-test)
+
+;;; pel-read-test.el ends here

--- a/test/pel-read-test.el
+++ b/test/pel-read-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, April 16 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-16 22:08:40 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-16 22:35:21 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -65,8 +65,12 @@
     (should (= (point) 6))))          ; after "hello" (1-based, 6 = past 'o')
 
 (ert-deftest pel-read/thing-at-point/signals-user-error-when-absent ()
-  "Signals `user-error' (not `error') when no thing is at point."
+  "Signals `user-error' when no word thing is at point (whitespace or empty)."
+  ;; Use a buffer with only whitespace: Emacs 26.1 guards are in pel-thing-at-point.
   (pel-read-test--with-buffer "   "
+    (should-error (pel-thing-at-point 'word) :type 'user-error))
+  ;; Also verify with an empty buffer.
+  (with-temp-buffer
     (should-error (pel-thing-at-point 'word) :type 'user-error)))
 
 (ert-deftest pel-read/thing-at-point/returns-sentence ()
@@ -106,8 +110,11 @@
         (should called)))))
 
 (ert-deftest pel-read/word-at-point/no-word-signals-user-error ()
-  "Signals `user-error' when no word is at point."
+  "Signals `user-error' when no word is at point (whitespace or empty)."
   (pel-read-test--with-buffer "   "
+    (should-error (pel-word-at-point t) :type 'user-error))
+  ;; test empty buffer
+  (with-temp-buffer
     (should-error (pel-word-at-point t) :type 'user-error)))
 
 (ert-deftest pel-read/word-at-point/return-type-is-string ()

--- a/test/pel-read-test.el
+++ b/test/pel-read-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, April 16 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-17 07:35:15 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-17 08:59:37 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -385,13 +385,21 @@ Stubs pel-forward-word-start so the test does not depend on pel-navigate."
 ;; ---------------------------------------------------------------------------
 ;; pel-sentence-at-point — additional cases
 
+;; After:
 (ert-deftest pel-read/sentence-at-point/whitespace-only-signals-user-error ()
   "Signals `user-error' when the buffer contains only whitespace.
-Unlike the word case, pel-thing-at-point does not apply the whitespace guard
-for \\='sentence, so this test documents that bounds-of-thing-at-point returns
-nil on whitespace-only content for sentences in all supported Emacs versions."
+Some Emacs versions (e.g. 26.1, 28.1) return non-nil bounds for whitespace
+when using bounds-of-thing-at-point for \\='sentence; pel-thing-at-point guards
+against this case for \\='word, \\='sentence and \\='paragraph."
   (pel-read-test--with-buffer "   "
     (should-error (pel-sentence-at-point t) :type 'user-error)))
+
+(ert-deftest pel-read/paragraph-at-point/whitespace-only-signals-user-error ()
+  "Signals `user-error' when the buffer contains only whitespace.
+Some Emacs versions return non-nil bounds for whitespace when using
+bounds-of-thing-at-point for \\='paragraph; pel-thing-at-point guards this."
+  (pel-read-test--with-buffer "   "
+    (should-error (pel-paragraph-at-point t) :type 'user-error)))
 
 ;; ---------------------------------------------------------------------------
 ;; pel-move-past-face — explicit non-nil guard

--- a/test/pel-read-test.el
+++ b/test/pel-read-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, April 16 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-16 22:35:21 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-17 07:35:15 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -62,7 +62,8 @@
   "Moves point to the end of the matched thing (cdr of bounds)."
   (pel-read-test--with-buffer "hello world"
     (pel-thing-at-point 'word)
-    (should (= (point) 6))))          ; after "hello" (1-based, 6 = past 'o')
+    ;; "hello" occupies positions 1-5; point 6 is the space that follows it
+    (should (= (point) 6))))
 
 (ert-deftest pel-read/thing-at-point/signals-user-error-when-absent ()
   "Signals `user-error' when no word thing is at point (whitespace or empty)."
@@ -77,11 +78,6 @@
   "Returns the sentence text at point."
   (pel-read-test--with-buffer "Hello world.  Goodbye."
     (should (string= "Hello world." (pel-thing-at-point 'sentence)))))
-
-(ert-deftest pel-read/thing-at-point/empty-buffer-signals-user-error ()
-  "Signals `user-error' in an empty buffer."
-  (with-temp-buffer
-    (should-error (pel-thing-at-point 'word) :type 'user-error)))
 
 ;; ---------------------------------------------------------------------------
 ;; pel-word-at-point
@@ -192,8 +188,8 @@
 (ert-deftest pel-read/string-at-point/point-inside-quoted-string ()
   "Extracts the substring between quote delimiters when point is inside."
   (pel-read-test--with-buffer "\"hello\""
-                              (goto-char 2) ; inside the quotes
-                              (should (string= "hello" (pel-string-at-point "\"")))))
+    (goto-char 2)                       ; inside the quotes
+    (should (string= "hello" (pel-string-at-point "\"")))))
 
 (ert-deftest pel-read/string-at-point/point-at-opening-delimiter ()
   "Extracts substring correctly when point is at the opening delimiter."
@@ -346,6 +342,74 @@
     (put-text-property 1 12 'face 'custom-variable-tag)
     (goto-char (point-min))
     (should (string= "Foo Bar Baz" (pel-customize-symbol-at-line)))))
+
+;; ---------------------------------------------------------------------------
+;; pel-string-at-point — additional cases
+
+(ert-deftest pel-read/string-at-point/point-at-closing-delimiter ()
+  "Point at the closing delimiter: forward-char overshoots, returns empty string.
+When point is on a closing delimiter, the implementation treats it as an
+opening delimiter (at-delimiter is non-nil), steps forward one char past it,
+then finds no further content before the next delimiter → returns \"\"."
+  (pel-read-test--with-buffer "\"hello\""
+    (goto-char 7)                         ; at closing quote (position 7)
+    (should (string= "" (pel-string-at-point "\"")))))
+
+;; ---------------------------------------------------------------------------
+;; pel-move-to-face — additional cases
+
+(ert-deftest pel-read/move-to-face/point-already-on-face ()
+  "Returns current point immediately when point is already on the target face.
+The while loop's condition is false from the start so point never advances."
+  (with-temp-buffer
+    (insert "abcdef")
+    ;; positions 1-4 (\"abcd\") carry the face
+    (put-text-property 1 5 'face 'pel-test-face)
+    (goto-char (point-min))             ; position 1 — already on the face
+    (let ((result (pel-move-to-face 'pel-test-face (point-max))))
+      (should result)                   ; must not be nil
+      (should (= result 1))
+      (should (= (point) 1)))))         ; point must not have moved
+
+;; ---------------------------------------------------------------------------
+;; pel-word-at-point — additional cases
+
+(ert-deftest pel-read/word-at-point/returns-word-when-stay-is-nil ()
+  "Returns the correct word string even when STAY is nil (move-after mode).
+Stubs pel-forward-word-start so the test does not depend on pel-navigate."
+  (pel-read-test--with-buffer "emacs lisp"
+    (cl-letf (((symbol-function 'pel-forward-word-start)
+               (lambda () nil)))        ; stub: suppress real navigation
+      (should (string= "emacs" (pel-word-at-point))))))
+
+;; ---------------------------------------------------------------------------
+;; pel-sentence-at-point — additional cases
+
+(ert-deftest pel-read/sentence-at-point/whitespace-only-signals-user-error ()
+  "Signals `user-error' when the buffer contains only whitespace.
+Unlike the word case, pel-thing-at-point does not apply the whitespace guard
+for \\='sentence, so this test documents that bounds-of-thing-at-point returns
+nil on whitespace-only content for sentences in all supported Emacs versions."
+  (pel-read-test--with-buffer "   "
+    (should-error (pel-sentence-at-point t) :type 'user-error)))
+
+;; ---------------------------------------------------------------------------
+;; pel-move-past-face — explicit non-nil guard
+
+(ert-deftest pel-read/move-past-face/advances-past-face-region/result-not-nil ()
+  "Advances past a face region: result is non-nil and equals expected position.
+This companion test to the main advances-past test adds an explicit non-nil
+assertion before the equality check, since (= nil 5) would signal a
+wrong-type-argument rather than a clean ert-test-failed."
+  (with-temp-buffer
+    (insert "abcdef")
+    ;; positions 1-4 (\"abcd\") carry the face
+    (put-text-property 1 5 'face 'pel-test-face)
+    (goto-char (point-min))
+    (let ((result (pel-move-past-face 'pel-test-face (point-max))))
+      (should result)                   ; explicit non-nil guard
+      (should (= result 5))
+      (should (= (point) 5)))))
 
 ;;; --------------------------------------------------------------------------
 (provide 'pel-read-test)

--- a/test/pel-read-test.el
+++ b/test/pel-read-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, April 16 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-17 11:21:58 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-17 15:22:56 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -87,6 +87,13 @@
     (let ((result (pel-thing-at-point 'paragraph)))
       (should (stringp result))
       (should (string-match-p "First paragraph" result)))))
+
+(ert-deftest pel-read/thing-at-point/moves-past-sentence ()
+  "Moves point to the end of the matched sentence (cdr of bounds)."
+  (pel-read-test--with-buffer "Hello world.  Goodbye."
+    (pel-thing-at-point 'sentence)
+    ;; "Hello world." occupies positions 1–12; point 13 is the first space after
+    (should (= (point) 13))))
 
 ;; ---------------------------------------------------------------------------
 ;; pel-word-at-point
@@ -283,7 +290,7 @@ then finds no further content before the next delimiter → returns \"\"."
     (should (string= "" (pel-string-at-point "\"")))))
 
 ;; ---------------------------------------------------------------------------
-;; pel-move-to-face
+;; pel--move-to-face
 
 (ert-deftest pel-read/move-to-face/finds-face-and-returns-point ()
   "Moves to the first char with the given face and returns that position."
@@ -292,7 +299,7 @@ then finds no further content before the next delimiter → returns \"\"."
     ;; chars at positions 3-5 ("cde") get the test face
     (put-text-property 3 6 'face 'pel-test-face)
     (goto-char (point-min))
-    (let ((result (pel-move-to-face 'pel-test-face (point-max))))
+    (let ((result (pel--move-to-face 'pel-test-face (point-max))))
       (should (= result 3))
       (should (= (point) 3)))))
 
@@ -301,7 +308,7 @@ then finds no further content before the next delimiter → returns \"\"."
   (with-temp-buffer
     (insert "abcdef")
     (goto-char (point-min))
-    (should (null (pel-move-to-face 'nonexistent-face (point-max))))))
+    (should (null (pel--move-to-face 'nonexistent-face (point-max))))))
 
 (ert-deftest pel-read/move-to-face/respects-limit ()
   "Does not cross the limit even if the face appears beyond it."
@@ -310,7 +317,7 @@ then finds no further content before the next delimiter → returns \"\"."
     (put-text-property 5 7 'face 'pel-test-face)  ; "ef" has the face
     (goto-char (point-min))
     ;; limit is 4, face starts at 5 → not found
-    (should (null (pel-move-to-face 'pel-test-face 4)))))
+    (should (null (pel--move-to-face 'pel-test-face 4)))))
 
 (ert-deftest pel-read/move-to-face/point-already-on-face ()
   "Returns current point immediately when point is already on the target face.
@@ -320,13 +327,13 @@ The while loop's condition is false from the start so point never advances."
     ;; positions 1-4 ("abcd") carry the face
     (put-text-property 1 5 'face 'pel-test-face)
     (goto-char (point-min))             ; position 1 — already on the face
-    (let ((result (pel-move-to-face 'pel-test-face (point-max))))
+    (let ((result (pel--move-to-face 'pel-test-face (point-max))))
       (should result)                   ; must not be nil
       (should (= result 1))
       (should (= (point) 1)))))         ; point must not have moved
 
 ;; ---------------------------------------------------------------------------
-;; pel-move-past-face
+;; pel--move-past-face
 
 (ert-deftest pel-read/move-past-face/advances-past-face-region ()
   "Moves point past the contiguous region carrying the specified face."
@@ -334,7 +341,7 @@ The while loop's condition is false from the start so point never advances."
     (insert "abcdef")
     (put-text-property 1 5 'face 'pel-test-face)
     (goto-char (point-min))
-    (let ((result (pel-move-past-face 'pel-test-face (point-max))))
+    (let ((result (pel--move-past-face 'pel-test-face (point-max))))
       (should result)                   ; explicit non-nil guard
       (should (= result 5))
       (should (= (point) 5)))))
@@ -345,7 +352,7 @@ The while loop's condition is false from the start so point never advances."
     (insert "abcdef")
     (put-text-property 1 7 'face 'pel-test-face)  ; entire content
     (goto-char (point-min))
-    (should (null (pel-move-past-face 'pel-test-face (point-max))))))
+    (should (null (pel--move-past-face 'pel-test-face (point-max))))))
 
 (ert-deftest pel-read/move-past-face/no-face-at-start-returns-current-point ()
   "Returns current point immediately when point is not on the given face."
@@ -353,7 +360,7 @@ The while loop's condition is false from the start so point never advances."
     (insert "abcdef")
     (put-text-property 3 6 'face 'pel-test-face)  ; only "cde"
     (goto-char (point-min))                        ; position 1 — no face here
-    (let ((result (pel-move-past-face 'pel-test-face (point-max))))
+    (let ((result (pel--move-past-face 'pel-test-face (point-max))))
       (should result)
       (should (= result 1)))))
 

--- a/test/pel-read-test.el
+++ b/test/pel-read-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, April 16 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-17 10:01:36 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-17 10:38:06 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -114,18 +114,28 @@
         (pel-word-at-point)
         (should called)))))
 
+(ert-deftest pel-read/sentence-at-point/no-word-signals-user-error ()
+  "Signals `user-error' in an empty buffer (no word)."
+  (with-temp-buffer
+    (should-error (pel-word-at-point t) :type 'user-error)))
+
 (ert-deftest pel-read/word-at-point/no-word-signals-user-error ()
   "Signals `user-error' when no word is at point (whitespace or empty)."
   (pel-read-test--with-buffer "   "
-    (should-error (pel-word-at-point t) :type 'user-error))
-  ;; test empty buffer
-  (with-temp-buffer
     (should-error (pel-word-at-point t) :type 'user-error)))
 
 (ert-deftest pel-read/word-at-point/return-type-is-string ()
   "Return value is always a string."
   (pel-read-test--with-buffer "test"
     (should (stringp (pel-word-at-point t)))))
+
+(ert-deftest pel-read/word-at-point/returns-word-when-dont-move-is-nil ()
+  "Returns the correct word string even when DONT-MOVE is nil (move-after mode).
+Stubs pel-forward-word-start so the test does not depend on pel-navigate."
+  (pel-read-test--with-buffer "emacs lisp"
+    (cl-letf (((symbol-function 'pel-forward-word-start)
+               (lambda () nil)))        ; stub: suppress real navigation
+      (should (string= "emacs" (pel-word-at-point))))))
 
 ;; ---------------------------------------------------------------------------
 ;; pel-sentence-at-point
@@ -156,6 +166,21 @@
 (ert-deftest pel-read/sentence-at-point/no-sentence-signals-user-error ()
   "Signals `user-error' in an empty buffer (no sentence)."
   (with-temp-buffer
+    (should-error (pel-sentence-at-point t) :type 'user-error)))
+
+(ert-deftest pel-read/sentence-at-point/returns-sentence-when-dont-move-is-nil ()
+  "Returns correct sentence text even when DONT-MOVE is nil (move-after mode)."
+  (pel-read-test--with-buffer "Hello world.  Goodbye."
+    (cl-letf (((symbol-function 'pel-forward-word-start)
+               (lambda () nil)))
+      (should (string= "Hello world." (pel-sentence-at-point))))))
+
+(ert-deftest pel-read/sentence-at-point/whitespace-only-signals-user-error ()
+  "Signals `user-error' when the buffer contains only whitespace.
+Some Emacs versions (e.g. 26.1, 28.1) return non-nil bounds for whitespace
+when using bounds-of-thing-at-point for \\='sentence; pel-thing-at-point guards
+against this case for \\='word, \\='sentence and \\='paragraph."
+  (pel-read-test--with-buffer "   "
     (should-error (pel-sentence-at-point t) :type 'user-error)))
 
 ;; ---------------------------------------------------------------------------
@@ -189,6 +214,22 @@
 (ert-deftest pel-read/paragraph-at-point/no-paragraph-signals-user-error ()
   "Signals `user-error' when no paragraph exists at point."
   (with-temp-buffer
+    (should-error (pel-paragraph-at-point t) :type 'user-error)))
+
+(ert-deftest pel-read/paragraph-at-point/returns-paragraph-when-dont-move-is-nil ()
+  "Returns correct paragraph text even when DONT-MOVE is nil (move-after mode)."
+  (pel-read-test--with-buffer "First paragraph.\n\nSecond paragraph."
+    (cl-letf (((symbol-function 'pel-forward-word-start)
+               (lambda () nil)))
+      (let ((result (pel-paragraph-at-point)))
+        (should (stringp result))
+        (should (string-match-p "First paragraph" result))))))
+
+(ert-deftest pel-read/paragraph-at-point/whitespace-only-signals-user-error ()
+  "Signals `user-error' when the buffer contains only whitespace.
+Some Emacs versions return non-nil bounds for whitespace when using
+bounds-of-thing-at-point for \\='paragraph; pel-thing-at-point guards this."
+  (pel-read-test--with-buffer "   "
     (should-error (pel-paragraph-at-point t) :type 'user-error)))
 
 ;; ---------------------------------------------------------------------------
@@ -237,6 +278,15 @@
       (pel-string-at-point "\"")
       (should (= pos (point))))))
 
+(ert-deftest pel-read/string-at-point/point-at-closing-delimiter ()
+  "Point at the closing delimiter: forward-char overshoots, returns empty string.
+When point is on a closing delimiter, the implementation treats it as an
+opening delimiter (at-delimiter is non-nil), steps forward one char past it,
+then finds no further content before the next delimiter → returns \"\"."
+  (pel-read-test--with-buffer "\"hello\""
+    (goto-char 7)                         ; at closing quote (position 7)
+    (should (string= "" (pel-string-at-point "\"")))))
+
 ;; ---------------------------------------------------------------------------
 ;; pel-move-to-face
 
@@ -267,6 +317,19 @@
     ;; limit is 4, face starts at 5 → not found
     (should (null (pel-move-to-face 'pel-test-face 4)))))
 
+(ert-deftest pel-read/move-to-face/point-already-on-face ()
+  "Returns current point immediately when point is already on the target face.
+The while loop's condition is false from the start so point never advances."
+  (with-temp-buffer
+    (insert "abcdef")
+    ;; positions 1-4 ("abcd") carry the face
+    (put-text-property 1 5 'face 'pel-test-face)
+    (goto-char (point-min))             ; position 1 — already on the face
+    (let ((result (pel-move-to-face 'pel-test-face (point-max))))
+      (should result)                   ; must not be nil
+      (should (= result 1))
+      (should (= (point) 1)))))         ; point must not have moved
+
 ;; ---------------------------------------------------------------------------
 ;; pel-move-past-face
 
@@ -277,7 +340,7 @@
     (put-text-property 1 5 'face 'pel-test-face)
     (goto-char (point-min))
     (let ((result (pel-move-past-face 'pel-test-face (point-max))))
-      (should result)          ; explicit non-nil guard
+      (should result)                   ; explicit non-nil guard
       (should (= result 5))
       (should (= (point) 5)))))
 
@@ -313,8 +376,8 @@
   "Returns the text carrying the custom-variable-tag face."
   (with-temp-buffer
     (insert "   My Symbol   rest of line")
-    ;;       123456789012345
-    ;; "My Symbol" occupies positions 4-12 (9 chars, exclusive end = 13)
+    ;; pos:  123456789012345
+    ;; ------> "My Symbol" occupies positions 4-12 (9 chars, exclusive end = 13)
     (put-text-property 4 13 'face 'custom-variable-tag)
     (goto-char (point-min))
     (should (string= "My Symbol" (pel-customize-symbol-at-line)))))
@@ -352,82 +415,6 @@
     (put-text-property 1 12 'face 'custom-variable-tag)
     (goto-char (point-min))
     (should (string= "Foo Bar Baz" (pel-customize-symbol-at-line)))))
-
-;; ---------------------------------------------------------------------------
-;; pel-string-at-point — additional cases
-
-(ert-deftest pel-read/string-at-point/point-at-closing-delimiter ()
-  "Point at the closing delimiter: forward-char overshoots, returns empty string.
-When point is on a closing delimiter, the implementation treats it as an
-opening delimiter (at-delimiter is non-nil), steps forward one char past it,
-then finds no further content before the next delimiter → returns \"\"."
-  (pel-read-test--with-buffer "\"hello\""
-    (goto-char 7)                         ; at closing quote (position 7)
-    (should (string= "" (pel-string-at-point "\"")))))
-
-;; ---------------------------------------------------------------------------
-;; pel-move-to-face — additional cases
-
-(ert-deftest pel-read/move-to-face/point-already-on-face ()
-  "Returns current point immediately when point is already on the target face.
-The while loop's condition is false from the start so point never advances."
-  (with-temp-buffer
-    (insert "abcdef")
-    ;; positions 1-4 (\"abcd\") carry the face
-    (put-text-property 1 5 'face 'pel-test-face)
-    (goto-char (point-min))             ; position 1 — already on the face
-    (let ((result (pel-move-to-face 'pel-test-face (point-max))))
-      (should result)                   ; must not be nil
-      (should (= result 1))
-      (should (= (point) 1)))))         ; point must not have moved
-
-;; ---------------------------------------------------------------------------
-;; pel-word-at-point — additional cases
-
-(ert-deftest pel-read/word-at-point/returns-word-when-dont-move-is-nil ()
-  "Returns the correct word string even when DONT-MOVE is nil (move-after mode).
-Stubs pel-forward-word-start so the test does not depend on pel-navigate."
-  (pel-read-test--with-buffer "emacs lisp"
-    (cl-letf (((symbol-function 'pel-forward-word-start)
-               (lambda () nil)))        ; stub: suppress real navigation
-      (should (string= "emacs" (pel-word-at-point))))))
-
-;; ---------------------------------------------------------------------------
-;; pel-sentence-at-point — additional cases
-
-(ert-deftest pel-read/sentence-at-point/returns-sentence-when-dont-move-is-nil ()
-  "Returns correct sentence text even when DONT-MOVE is nil (move-after mode)."
-  (pel-read-test--with-buffer "Hello world.  Goodbye."
-    (cl-letf (((symbol-function 'pel-forward-word-start)
-               (lambda () nil)))
-      (should (string= "Hello world." (pel-sentence-at-point))))))
-
-(ert-deftest pel-read/sentence-at-point/whitespace-only-signals-user-error ()
-  "Signals `user-error' when the buffer contains only whitespace.
-Some Emacs versions (e.g. 26.1, 28.1) return non-nil bounds for whitespace
-when using bounds-of-thing-at-point for \\='sentence; pel-thing-at-point guards
-against this case for \\='word, \\='sentence and \\='paragraph."
-  (pel-read-test--with-buffer "   "
-    (should-error (pel-sentence-at-point t) :type 'user-error)))
-
-;; ---------------------------------------------------------------------------
-;; pel-paragraph-at-point — additional cases
-
-(ert-deftest pel-read/paragraph-at-point/returns-paragraph-when-dont-move-is-nil ()
-  "Returns correct paragraph text even when DONT-MOVE is nil (move-after mode)."
-  (pel-read-test--with-buffer "First paragraph.\n\nSecond paragraph."
-    (cl-letf (((symbol-function 'pel-forward-word-start)
-               (lambda () nil)))
-      (let ((result (pel-paragraph-at-point)))
-        (should (stringp result))
-        (should (string-match-p "First paragraph" result))))))
-
-(ert-deftest pel-read/paragraph-at-point/whitespace-only-signals-user-error ()
-  "Signals `user-error' when the buffer contains only whitespace.
-Some Emacs versions return non-nil bounds for whitespace when using
-bounds-of-thing-at-point for \\='paragraph; pel-thing-at-point guards this."
-  (pel-read-test--with-buffer "   "
-    (should-error (pel-paragraph-at-point t) :type 'user-error)))
 
 ;;; --------------------------------------------------------------------------
 (provide 'pel-read-test)

--- a/test/pel-read-test.el
+++ b/test/pel-read-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, April 16 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-17 11:19:22 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-17 11:21:58 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -113,11 +113,6 @@
                  (lambda () (setq called t))))
         (pel-word-at-point)
         (should called)))))
-
-(ert-deftest pel-read/word-at-point/no-word-signals-user-error ()
-  "Signals `user-error' in an empty buffer (no word)."
-  (with-temp-buffer
-    (should-error (pel-word-at-point t) :type 'user-error)))
 
 (ert-deftest pel-read/word-at-point/no-word-signals-user-error ()
   "Signals `user-error' when no word is at point (whitespace or empty)."

--- a/test/pel-read-test.el
+++ b/test/pel-read-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, April 16 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-17 09:37:49 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-17 10:01:36 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -26,6 +26,8 @@
 ;;; Commentary:
 ;;
 ;; Test pel-read.el functions.
+;;
+;; Use make to run the tests from the command line.
 
 ;;; --------------------------------------------------------------------------
 ;;; Dependencies:
@@ -78,6 +80,13 @@
   "Returns the sentence text at point."
   (pel-read-test--with-buffer "Hello world.  Goodbye."
     (should (string= "Hello world." (pel-thing-at-point 'sentence)))))
+
+(ert-deftest pel-read/thing-at-point/returns-paragraph ()
+  "Returns the paragraph text when point is inside a paragraph."
+  (pel-read-test--with-buffer "First paragraph.\n\nSecond paragraph."
+    (let ((result (pel-thing-at-point 'paragraph)))
+      (should (stringp result))
+      (should (string-match-p "First paragraph" result)))))
 
 ;; ---------------------------------------------------------------------------
 ;; pel-word-at-point
@@ -375,13 +384,16 @@ The while loop's condition is false from the start so point never advances."
 ;; ---------------------------------------------------------------------------
 ;; pel-word-at-point — additional cases
 
-(ert-deftest pel-read/word-at-point/returns-word-when-stay-is-nil ()
-  "Returns the correct word string even when STAY is nil (move-after mode).
+(ert-deftest pel-read/word-at-point/returns-word-when-dont-move-is-nil ()
+  "Returns the correct word string even when DONT-MOVE is nil (move-after mode).
 Stubs pel-forward-word-start so the test does not depend on pel-navigate."
   (pel-read-test--with-buffer "emacs lisp"
     (cl-letf (((symbol-function 'pel-forward-word-start)
                (lambda () nil)))        ; stub: suppress real navigation
       (should (string= "emacs" (pel-word-at-point))))))
+
+;; ---------------------------------------------------------------------------
+;; pel-sentence-at-point — additional cases
 
 (ert-deftest pel-read/sentence-at-point/returns-sentence-when-dont-move-is-nil ()
   "Returns correct sentence text even when DONT-MOVE is nil (move-after mode)."
@@ -389,6 +401,17 @@ Stubs pel-forward-word-start so the test does not depend on pel-navigate."
     (cl-letf (((symbol-function 'pel-forward-word-start)
                (lambda () nil)))
       (should (string= "Hello world." (pel-sentence-at-point))))))
+
+(ert-deftest pel-read/sentence-at-point/whitespace-only-signals-user-error ()
+  "Signals `user-error' when the buffer contains only whitespace.
+Some Emacs versions (e.g. 26.1, 28.1) return non-nil bounds for whitespace
+when using bounds-of-thing-at-point for \\='sentence; pel-thing-at-point guards
+against this case for \\='word, \\='sentence and \\='paragraph."
+  (pel-read-test--with-buffer "   "
+    (should-error (pel-sentence-at-point t) :type 'user-error)))
+
+;; ---------------------------------------------------------------------------
+;; pel-paragraph-at-point — additional cases
 
 (ert-deftest pel-read/paragraph-at-point/returns-paragraph-when-dont-move-is-nil ()
   "Returns correct paragraph text even when DONT-MOVE is nil (move-after mode)."
@@ -398,17 +421,6 @@ Stubs pel-forward-word-start so the test does not depend on pel-navigate."
       (let ((result (pel-paragraph-at-point)))
         (should (stringp result))
         (should (string-match-p "First paragraph" result))))))
-
-;; ---------------------------------------------------------------------------
-;; pel-sentence-at-point — additional cases
-
-(ert-deftest pel-read/sentence-at-point/whitespace-only-signals-user-error ()
-  "Signals `user-error' when the buffer contains only whitespace.
-Some Emacs versions (e.g. 26.1, 28.1) return non-nil bounds for whitespace
-when using bounds-of-thing-at-point for \\='sentence; pel-thing-at-point guards
-against this case for \\='word, \\='sentence and \\='paragraph."
-  (pel-read-test--with-buffer "   "
-    (should-error (pel-sentence-at-point t) :type 'user-error)))
 
 (ert-deftest pel-read/paragraph-at-point/whitespace-only-signals-user-error ()
   "Signals `user-error' when the buffer contains only whitespace.

--- a/test/pel-read-test.el
+++ b/test/pel-read-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, April 16 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-17 08:59:37 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-04-17 09:37:49 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -25,7 +25,7 @@
 ;;; --------------------------------------------------------------------------
 ;;; Commentary:
 ;;
-;;
+;; Test pel-read.el functions.
 
 ;;; --------------------------------------------------------------------------
 ;;; Dependencies:
@@ -265,10 +265,10 @@
   "Moves point past the contiguous region carrying the specified face."
   (with-temp-buffer
     (insert "abcdef")
-    ;; positions 1-4 ("abcd") have the face
     (put-text-property 1 5 'face 'pel-test-face)
     (goto-char (point-min))
     (let ((result (pel-move-past-face 'pel-test-face (point-max))))
+      (should result)          ; explicit non-nil guard
       (should (= result 5))
       (should (= (point) 5)))))
 
@@ -287,6 +287,7 @@
     (put-text-property 3 6 'face 'pel-test-face)  ; only "cde"
     (goto-char (point-min))                        ; position 1 — no face here
     (let ((result (pel-move-past-face 'pel-test-face (point-max))))
+      (should result)
       (should (= result 1)))))
 
 ;; ---------------------------------------------------------------------------
@@ -382,10 +383,25 @@ Stubs pel-forward-word-start so the test does not depend on pel-navigate."
                (lambda () nil)))        ; stub: suppress real navigation
       (should (string= "emacs" (pel-word-at-point))))))
 
+(ert-deftest pel-read/sentence-at-point/returns-sentence-when-dont-move-is-nil ()
+  "Returns correct sentence text even when DONT-MOVE is nil (move-after mode)."
+  (pel-read-test--with-buffer "Hello world.  Goodbye."
+    (cl-letf (((symbol-function 'pel-forward-word-start)
+               (lambda () nil)))
+      (should (string= "Hello world." (pel-sentence-at-point))))))
+
+(ert-deftest pel-read/paragraph-at-point/returns-paragraph-when-dont-move-is-nil ()
+  "Returns correct paragraph text even when DONT-MOVE is nil (move-after mode)."
+  (pel-read-test--with-buffer "First paragraph.\n\nSecond paragraph."
+    (cl-letf (((symbol-function 'pel-forward-word-start)
+               (lambda () nil)))
+      (let ((result (pel-paragraph-at-point)))
+        (should (stringp result))
+        (should (string-match-p "First paragraph" result))))))
+
 ;; ---------------------------------------------------------------------------
 ;; pel-sentence-at-point — additional cases
 
-;; After:
 (ert-deftest pel-read/sentence-at-point/whitespace-only-signals-user-error ()
   "Signals `user-error' when the buffer contains only whitespace.
 Some Emacs versions (e.g. 26.1, 28.1) return non-nil bounds for whitespace
@@ -400,24 +416,6 @@ Some Emacs versions return non-nil bounds for whitespace when using
 bounds-of-thing-at-point for \\='paragraph; pel-thing-at-point guards this."
   (pel-read-test--with-buffer "   "
     (should-error (pel-paragraph-at-point t) :type 'user-error)))
-
-;; ---------------------------------------------------------------------------
-;; pel-move-past-face — explicit non-nil guard
-
-(ert-deftest pel-read/move-past-face/advances-past-face-region/result-not-nil ()
-  "Advances past a face region: result is non-nil and equals expected position.
-This companion test to the main advances-past test adds an explicit non-nil
-assertion before the equality check, since (= nil 5) would signal a
-wrong-type-argument rather than a clean ert-test-failed."
-  (with-temp-buffer
-    (insert "abcdef")
-    ;; positions 1-4 (\"abcd\") carry the face
-    (put-text-property 1 5 'face 'pel-test-face)
-    (goto-char (point-min))
-    (let ((result (pel-move-past-face 'pel-test-face (point-max))))
-      (should result)                   ; explicit non-nil guard
-      (should (= result 5))
-      (should (= (point) 5)))))
 
 ;;; --------------------------------------------------------------------------
 (provide 'pel-read-test)


### PR DESCRIPTION
Add optional argument dont-move to the following functions:
- pel-word-at-point
- pel-sentence-at-point
- pel-paragraph-at-point

Improve docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reading helpers gain an optional flag to return extracted text without moving the cursor.

* **Bug Fixes**
  * Absent or whitespace-only targets now raise a clearer, user-friendly error and are treated as missing.

* **Documentation**
  * Docstrings and commentary clarified to reflect behavior and return semantics.

* **Tests**
  * Added comprehensive tests covering extraction, cursor movement, error signaling, face-based helpers.

* **Chores**
  * Build targets updated to run and track the new test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->