### PR TITLE
More info on fast mode - investigate double pel-bundle in Emacs > 28

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-2026 by Pierre Rouleau
 
 # Author: Pierre Rouleau <prouleau001@gmail.com>
-# Last Modified Time-stamp: <2026-05-12 17:44:48 EDT, updated by Pierre Rouleau>
+# Last Modified Time-stamp: <2026-05-17 21:48:20 EDT, updated by Pierre Rouleau>
 # Keywords: packaging, build-control
 
 # This file is part of the PEL package
@@ -943,6 +943,7 @@ test/pel-elpa-test.el.test-passed:              pel-elpa.elc pel-filedir.elc
 test/pel-erlang-activation-test.el.test-passed: pel--install.elc pel_keys.elc
 test/pel-erlang-test.el.test-passed:            pel-erlang.elc pel-ert.elc
 test/pel-ert-test.el.test-passed:               pel-ert.elc
+test/pel-fast-startup-init-test.el.test-passed: pel-setup.elc
 test/pel-ffind-inpath-test.el.test-passed:      pel-ffind-inpath.elc
 test/pel-ffind-test.el.test-passed:             pel-ffind.elc
 test/pel-ffind-project-rootdir-test.el.test-passed: pel-ffind.elc pel--options.elc

--- a/NEWS
+++ b/NEWS
@@ -128,6 +128,7 @@ PEL -- Pragmatic Emacs Library --  NEWS         -*- org -*-
       also allows the user to switch easily from classic mode to Tree-Sitter mode with the *pel-treesit-toggle-mode* command.
       The macro takes Emacs version into account and generates code that is valid for that version of Emacs.
       This simplifies writing PEL code for new major modes.  It is now used in pel_keys.el for several major modes.
+- Improved statistics: The *pel-package-info* command, also accessible via the *make stats* command, now report the number of packages PEL can install with quelpa.
 - Improved PDF files:
   - ⅀ Diff & Merge: Describe how to create a patch file from a diff-mode buffer.
   - ⅀ Faces/Fonts: more about changing a face.

--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,9 @@ PEL -- Pragmatic Emacs Library
   `😃`_
 - You *also* want to `run Emacs daemon(s) with text and graphics clients`_ on
   linux and macOS like a pro? `🥳`_
+- And you want **fast** Emacs startup?  On a 2023 macOS Apple
+  Silicon computer PEL starts Emacs with **303 elpa packages and 108 other
+  single file packages in 0.16 seconds** and it's even faster on Linux! 😲
 
 PEL might be for you!  Then go ahead, `install it`_ [#install]_
 or `update it`_ [#update]_ ! Leave `feedback in the discussion`_ if you wish.
@@ -246,10 +249,42 @@ Again any feedback is welcome. Thanks!
   - With PEL you can see a quick report with relevant information by executing
     the `pel-emacs-load-stats` command.
 
-    - On a 2023 macStudio running Emacs 30.2 mode with PEL 0.4.2
-      under macOS, fast startup achieves a 0.18 seconds average in terminal
-      mode for 421 loaded files and 0.23 seconds average in graphical for 461
-      loaded files.
+    - On a 2023 macStudio with Geekbench 6.7.1 rate of 2490 single-code/13076
+      multicore, with **303 elpa packages and 108 other non-elpa single file
+      packages** installed from their repos, Emacs 30.2 takes about 0.67 seconds to
+      start in normal mode but takes just about **0.17 seconds** in terminal mode
+      and **0.23 seconds** in graphics mode.
+
+      More details:
+
+      - 303 Elpa packages stored in: ~/.emacs.d/elpa-complete/
+      - 108 Utils files   stored in: ~/.emacs.d/utils/
+      - size of load-path          : 333 directories
+      - # pel-use-... user-options : 422 (343 are active)
+
+      In normal mode::
+
+         GNU Emacs 30.2.50 (build 2, aarch64-apple-darwin23.6.0, NS appkit-2487.70 Version 14.8.2 (Build 23J126)) of 2025-11-26
+         Emacs 30.2.50 startup time: 0.677794 seconds   (in normal mode, with package quickstart, with native compilation, in terminal mode.)
+         # loaded files         : 433
+         # load-path length     : 332
+         # features             : 720
+         # package-alist        : 303
+         # packages activated   : 303
+         # packages selected    : 190
+
+      With PEL fast startup mode activated::
+
+         GNU Emacs 30.2.50 (build 2, aarch64-apple-darwin23.6.0, NS appkit-2487.70 Version 14.8.2 (Build 23J126)) of 2025-11-26
+         Emacs 30.2.50 startup time: 0.164187 seconds   (in fast mode, with package quickstart, with native compilation, in terminal mode.)
+         # loaded files         : 421
+         # load-path length     : 71
+         # features             : 445
+         # package-alist        : 41
+         # packages activated   : 41
+         # packages selected    : 190
+
+
 
   - Here's what I get on other systems with other versions of Emacs using the
     PEL fast startup mode:

--- a/pel--base.el
+++ b/pel--base.el
@@ -1144,6 +1144,8 @@ The index of the first whitespace character is returned when one is present."
   (when (> (length text) 0)
     (string= (substring text 0 1) " ")))
 
+;; [:todo 2026-05-16, by Pierre Rouleau: string-suffix-p should be used
+;; instead of pel-string-ends-with-p]
 (defun pel-string-ends-with-p (text suffix &optional ignore-case)
   "Return t if TEXT string does end with SUFFIX string, nil otherwise.
 Ignore case differences if IGNORE-CASE is non-nil."
@@ -1155,6 +1157,8 @@ Ignore case differences if IGNORE-CASE is non-nil."
                                 text (- text-len suffix-len) nil
                                 ignore-case)))))
 
+;; [:todo 2026-05-16, by Pierre Rouleau: string-prefix-p should be used
+;;                                       instead of pel-string-starts-with-p]
 (defun pel-string-starts-with-p (text prefix &optional ignore-case)
   "Return t if TEXT string does start with PREFIX string, nil otherwise.
 Ignore case differences if IGNORE-CASE is non-nil."

--- a/pel--options.el
+++ b/pel--options.el
@@ -447,7 +447,7 @@
 ;; - Erlang
 ;; - Gleam
 ;; - Go
-;; - Js (Javascript)
+;; - Js (JavaScript)
 ;; - Lua
 ;; - Nim
 ;; - Ruby

--- a/pel-elpa.el
+++ b/pel-elpa.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Wednesday, June 30 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-17 22:24:30 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-18 10:31:42 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -412,13 +412,13 @@ function does not attempt to detect duplicate and returns nil."
               ;; note: the destination will hold the name of the other
               ;;       file when with-symlinks true.  But report the issue
               ;;       as a warning.
-              (progn
-                (push (cons src-fn (file-truename dst-fn))
-                      duplicates)
+              (let ((new src-fn)
+                    (existing (file-truename dst-fn)))
+                (push (cons new existing) duplicates)
                 (display-warning
                  'pel-elpa-create-copies
-                 (format "Duplicate file name in bundle: %s\n existing: %s"
-                         (car duplicates) (cdr (car duplicates)))
+                 (format "Duplicate file name in bundle:\n new: %s\n existing: %s"
+                         new existing)
                  :warning))
             ;; destination does not exist (normal case):
             ;;   copy file or create symlink

--- a/pel-elpa.el
+++ b/pel-elpa.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Wednesday, June 30 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-14 17:12:59 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-17 22:24:30 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -417,7 +417,8 @@ function does not attempt to detect duplicate and returns nil."
                       duplicates)
                 (display-warning
                  'pel-elpa-create-copies
-                 (format "Duplicate file: %s" (car duplicates))
+                 (format "Duplicate file name in bundle: %s\n existing: %s"
+                         (car duplicates) (cdr (car duplicates)))
                  :warning))
             ;; destination does not exist (normal case):
             ;;   copy file or create symlink

--- a/pel-package.el
+++ b/pel-package.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Monday, March 22 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-03 15:53:21 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-15 11:55:29 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -89,8 +89,13 @@
 ;;
 ;;  The code identifies you local Elpa and utils directories and their attic
 ;;  counterparts, normally stored inside the ~/.emacs.d directory or the
-;;  equivalent.  The location of those directories is stored inside the
-;;  `pel-elpa-dirpath' defconst and the returned by the following functions:
+;;  equivalent.  The location of those directories when Emacs starts and load
+;;  this file is first stored inside the `pel--elpa-dirpath-original' defconst.
+;;  That value is returned by (`pel-elpa-dirpath' 'at-startup).  The current
+;;  value is returned by (`pel-elpa-dirpath 'now).
+;;
+;;   - `pel-elpa-dirpath'
+;;     - `pel-elpa-locate'
 ;;
 ;;   - `pel-elpa-attic-dirpath'
 ;;   - `pel-utils-dirpath'
@@ -170,47 +175,88 @@
 ;; [:todo 2024-01-05, by Pierre Rouleau: better handle unbound
 ;;                    pel-package-user-dir-original value.]
 (defun pel-locate-elpa ()
-  "Return the absolute path of the local Elpa directory.
+  "Return the absolute path of the local Elpa directory (or symlink).
 
-PEL init.el file changes the value of `package-user-dir' to
-ensure that the value used by package.el is a true directory
-name, not a symlink.  That is done to ensure that the entries
-inside the `load-path' remain valid even if an external Emacs/PEL
-process switches the startup mode and changes the target of the
-elpa symlink.
+PEL early-init.el and init.el file update the dynamic value of the Emacs
+`package-user-dir' user-option to ensure that the value used by
+package.el:
 
-Before this is done, the code stores the original value of
-`package-user-dir', which corresponds to the user-option value
-stored in the custom file, into `pel-package-user-dir-original'.
+- correspond to what is required when PEL operates in dual tty/graphics
+  setup environment for Emacs running in terminal or graphics mode,
+- is a true directory name, not the symlink that may point to it.
+
+This is done to ensure that the entries inside the `load-path' remain
+valid even if an external Emacs/PEL process switches the startup mode
+and changes the target of the elpa symlink.
+
+PEL init.el code stores the original value of `package-user-dir', which
+corresponds to the user-option value stored in the custom file, into
+`pel-package-user-dir-original'.
 
 PEL will be able to use this value to transform the original elpa
 directory into a symlink that points to a directory named
-\"elpa-complete\".
+\"elpa-complete\" or \"elpa-complete-graphics\" when dual tty/graphics
+mode is used and Emacs is a GUI process.
 
-It's possible that PEL is used with a init.el file that has not
-yet been populated with the proper code. In that case the
-`pel-package-user-dir-original' variable may not exist; in that
-case the function returns nil.
+It's possible that PEL is used with a init.el file that has not yet been
+populated with the proper code and pel-package-user-dir-original'
+variable does not exist. In that case the function report a warning and
+tries to locate the elpa directory the standard way using the standard
+`package-user-dir' or by building its path via the
+`user-emacs-directory' value.  If you get the warning you should update
+your init.el file (and possibly the early-init.el) by using what PEL provides
+in the example/init directory.
 
 In the remote possibility that `package-user-dir' is not bound
 then the \"elpa\" sub-directory of the directory identified by
 the variable `user-emacs-directory' is used."
-  (file-name-as-directory (if (bound-and-true-p pel-package-user-dir-original)
-                              (expand-file-name pel-package-user-dir-original)
-                            (if (and (require 'package nil :noerror)
-                                     (boundp 'package-user-dir))
-                                (expand-file-name package-user-dir)
-                              (expand-file-name "elpa" user-emacs-directory)))))
+  (file-name-as-directory
+   (if (bound-and-true-p pel-package-user-dir-original)
+       (expand-file-name pel-package-user-dir-original)
+     ;;
+     ;; `pel-package-user-dir-original' does not exist!
+     ;; You are not using a PEL compliant init.el file!
+     ;; But warn only at load or run time, not at compile time
+     (unless (or (bound-and-true-p byte-compile-current-file)
+                 (bound-and-true-p comp-native-compiling))
+       (let ((errmsg
+              (format "⚠️  Emacs init.el does not comply with PEL requirements!
+    Please update your init.el%s! Use PEL example/init files as templates."
+                      (if pel-emacs-27-or-later-p
+                          " and your early-init.el"
+                        ""))))
+         (if noninteractive
+             ;; If issued from a command line Emacs invocation stop with an
+             ;; error
+             (error errmsg)
+           ;; otherwise, during run time, just display warning error
+           (display-warning 'pel-locate-elpa errmsg :error))))
+     ;; Return something that is still valid for Emacs despite the problem.
+     (if (and (require 'package nil :noerror)
+              (boundp 'package-user-dir))
+         (expand-file-name package-user-dir)
+       (expand-file-name "elpa" user-emacs-directory)))))
 
 
-(defconst pel-elpa-dirpath  (pel-locate-elpa)
-  "Absolute path of the user elpa directory or symlink.
-This may differ from the value of `package-user-dir' when a symlink
-is used as PEL init files ensure that `package-user-dir' is set to the
-target of the elpa symlink while `pel-elpa-dirpath' is always set to the
-path of the elpa directory or symlink if it exists.
-Note that you can have several elpa directories if you set `package-user-dir'
-inside your init.el file.")
+(defconst pel--elpa-dirpath-original  (pel-locate-elpa)
+  "Absolute path of the user elpa directory or symlink used when Emacs starts.
+
+This may differ from the value of `package-user-dir' when a symlink is
+used as PEL init files ensure that `package-user-dir' is set to the
+target of the elpa symlink while `pel--elpa-dirpath-original' is always
+set to the path of the elpa directory or symlink if it exists.  Note
+that you can have several elpa directories if you set `package-user-dir'
+inside your init.el file.
+
+Evaluate (`pel-elpa-dirpath' \\='at-startup) to access this value.")
+
+(defun pel-elpa-dirpath (moment)
+  "Return absolute path of user elpa directory or symlink at specific MOMENT.
+MOMENT can be \\='at-startup or \\='now."
+  (cond
+   ((eq moment 'at-startup) pel--elpa-dirpath-original)
+   ((eq moment 'now) (pel-locate-elpa))
+   (t (error "Invalid pel-elpa-dirpath argument: %S" moment))))
 
 (defun pel-elpa-attic-dirpath ()
   "Return the absolute path of the user elpa-attic directory.
@@ -616,7 +662,7 @@ specified and non-nil.
 The list includes all packages that cannot be removed because of imposed
 restriction unless IGNORE-RESTRICTION is non-nil.
 
-Return a list of 2 lists:
+Return a list of 3 lists:
 - 1: list is a list of elpa package symbols,
 - 2: list is a list of utils file name symbols.
 - 3: list of error messages, if any
@@ -668,12 +714,14 @@ their names."
   "Insert a numbered list of packages in current buffer.
 
 PKGS is the list of packages to print.
-TITLE is the text that must be printed before the list."
+TITLE is the text that must be printed before the list.
+Return the length of PKGS."
   (let ((n 0))
     (insert title)
     (dolist (pkg pkgs)
       (pel+= n 1)
-      (insert (format "- %3d: %s\n" n pkg)))))
+      (insert (format "- %3d: %s\n" n pkg)))
+    n))
 
 (defun pel--show-pkgs-for (group-name all-pkgs pkgs+lock pkgs+deps to-keep)
   "Utility: insert description of used packages.
@@ -709,12 +757,9 @@ TO-KEEP:      List of package symbols or file name strings that are installed
 (defun pel--show-pkgs-in-excess-for (group pkgs)
   "Utility: list GROUP package PKGS in excess.
 Return the number of packages in excess."
-  (let ((n 0))
-    (when pkgs
-      (pel--insert-pkgs-list
-       (format "\n%s packages in excess:\n" group)
-       pkgs))
-    n))
+  (if pkgs
+      (pel--insert-pkgs-list (format "\n%s packages in excess:\n" group) pkgs)
+    0))
 
 ;; declare package.el variables  to prevent byte-compiler warnings
 (defvar package-selected-packages)
@@ -1141,7 +1186,8 @@ Return the number of symbols that were removed from the
 `package-selected-package' form."
   (let ((edited-filepath (or filepath custom-file))
         (pkgs (if (listp pkgs) pkgs (list pkgs)))
-        (remove-count 0))
+        (remove-count 0)
+        (original-superword-mode-state superword-mode))
     (with-temp-file edited-filepath
       (insert-file-contents edited-filepath)
       ;; use superword-mode to ensure that movement commands jump over
@@ -1177,13 +1223,14 @@ Return the number of symbols that were removed from the
                   (delete-char 1)))
               (pel+= remove-count 1))))
         (widen)
-        remove-count))))
+        remove-count))
+    ;; restore superword-mode to what it was before.
+    (superword-mode (if original-superword-mode-state 1 -1))))
 
-(defun pel-elpa-packages-in-dir ()
+(defun pel-elpa-packages-in-dir (moment)
   "Return a list of symbol for all packages present in local Elpa directory.
 
-The function search the directory identified by the variable
-`pel-elpa-dirpath'.
+The function search the directory identified by `pel-elpa-dirpath'.
 
 The directory holds sub-directories, one per package/version.
 The directory may hold several versions of a specific Elpa package.
@@ -1191,7 +1238,7 @@ The returned list contains only one symbol identifying the package for each
 version of that package.
 The list of package symbols is sorted by symbol names."
   (let ((elpa-pkg-dir-names  (directory-files
-                              pel-elpa-dirpath nil ".+[0-9-.]+\\'"))
+                              (pel-elpa-dirpath moment) nil ".+[0-9-.]+\\'"))
         (elpa-pkg-names ()))
     (dolist (dir-name elpa-pkg-dir-names)
       (when (eq 0 (string-match "\\`\\([^ ]+\\)-[0-9-.]+\\'" dir-name))
@@ -1207,7 +1254,7 @@ of their dependencies.
 The returned list contains symbols, each symbol is the name (without any
 version numbering) of the elpa package.  The list is sorted."
   (let ((activated-elpa (car (pel-activated-packages)))
-        (available-elpa (pel-elpa-packages-in-dir))
+        (available-elpa (pel-elpa-packages-in-dir 'now))
         (excess-elpa    ()))
     ;; Some packages are identified by the user as used, even though PEL may
     ;; not requests it via user-options; make sure to not identify these
@@ -1362,7 +1409,7 @@ intention by typing 'y' to its prompt.
 from: %s
 to  : %s :\n\n"
                              verb-moved
-                             pel-elpa-dirpath
+                             (pel-elpa-dirpath 'now)
                              (pel-elpa-attic-dirpath)))
              (setq n 0)
              (dolist (pkgdir moved-elpa-dirs)
@@ -1388,15 +1435,16 @@ The elpa-attic directory is the ~/.emacs.d/pel-elpa-attic directory."
   ;; MELPA packages which uses ISO-8601 format.
   (let ((elpa-attic-pkg-dirpath (car-safe
                                  (last (pel-elpa-dirs-for pkg :in-attic))))
-        (installation-succeeded nil))
+        (installation-succeeded nil)
+        (used-elpa-dirpath (pel-elpa-dirpath 'now)))
     (when elpa-attic-pkg-dirpath
       (let ((dest-dirpath
              (expand-file-name (file-name-nondirectory
                                 elpa-attic-pkg-dirpath)
-                               pel-elpa-dirpath)))
+                               used-elpa-dirpath)))
         (unless (file-exists-p dest-dirpath)
           (copy-directory elpa-attic-pkg-dirpath
-                          (file-name-as-directory pel-elpa-dirpath)
+                          (file-name-as-directory used-elpa-dirpath)
                           :keep-time))
         (push dest-dirpath load-path)
         (load-library (pel-as-string pkg))

--- a/pel-package.el
+++ b/pel-package.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Monday, March 22 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-15 11:55:29 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-15 13:23:02 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -218,7 +218,8 @@ the variable `user-emacs-directory' is used."
      ;; You are not using a PEL compliant init.el file!
      ;; But warn only at load or run time, not at compile time
      (unless (or (bound-and-true-p byte-compile-current-file)
-                 (bound-and-true-p comp-native-compiling))
+                 (bound-and-true-p comp-native-compiling)
+                 (getenv "EMACS_TEST_VERBOSE"))
        (let ((errmsg
               (format "⚠️  Emacs init.el does not comply with PEL requirements!
     Please update your init.el%s! Use PEL example/init files as templates."

--- a/pel-package.el
+++ b/pel-package.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Monday, March 22 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-16 14:31:44 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-16 15:56:28 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -1223,7 +1223,10 @@ The function assumes that:
                 (fn-b (file-name-nondirectory b)))
             (let ((v-a (and (string-match "-\\([0-9.]+\\)$" fn-a) (match-string 1 fn-a)))
                   (v-b (and (string-match "-\\([0-9.]+\\)$" fn-b) (match-string 1 fn-b))))
-              (version< v-a v-b))))))
+              (cond
+               ((and v-a v-b) (version< v-a v-b))
+               (v-b t)      ; a has no version, sort before b
+               (t nil))))))); b has no version or neither, keep order
 
 (defun pel-elpa-dirs-for (pkg &optional in-attic)
   "Return a list of directory names for specified package PKG.
@@ -1304,8 +1307,7 @@ Return the number of symbols that were removed from the
 `package-selected-package' form."
   (let ((edited-filepath (or filepath custom-file))
         (pkgs (if (listp pkgs) pkgs (list pkgs)))
-        (remove-count 0)
-        (original-superword-mode-state superword-mode))
+        (remove-count 0))
     (with-temp-file edited-filepath
       (insert-file-contents edited-filepath)
       ;; use superword-mode to ensure that movement commands jump over
@@ -1341,9 +1343,7 @@ Return the number of symbols that were removed from the
                   (delete-char 1)))
               (pel+= remove-count 1))))
         (widen)
-        remove-count))
-    ;; restore superword-mode to what it was before.
-    (superword-mode (if original-superword-mode-state 1 -1))))
+        remove-count))))
 
 (defun pel-elpa-packages-in-dir (type)
   "Return a list of symbol for all packages present in local Elpa directory.

--- a/pel-package.el
+++ b/pel-package.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Monday, March 22 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-17 22:28:25 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-18 10:08:49 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -161,6 +161,7 @@
 (require 'pel-elpa)             ; use: `pel-elpa-package-directories'
 ;;                              ;      `pel-el-files-in'
 (require 'cl-lib)               ; use: `cl-remove-if'
+(require 'seq)                  ; use: `seq-filter'
 
 ;;; --------------------------------------------------------------------------
 ;;; Code:
@@ -1639,7 +1640,10 @@ The elpa-attic directory is the ~/.emacs.d/pel-elpa-attic directory."
           (copy-directory elpa-attic-pkg-dirpath
                           (file-name-as-directory used-elpa-dirpath)
                           :keep-time))
-        (add-to-list 'load-path dest-dirpath)
+        ;; Add the directory to load-path if it does not already exists.
+        ;; Entries in load-path do not have the trailing "/"; therefore
+        ;; remove it from the one we enter.
+        (add-to-list 'load-path (directory-file-name dest-dirpath))
         (load-library (pel-as-string pkg))
         (setq installation-succeeded t)))
     installation-succeeded))

--- a/pel-package.el
+++ b/pel-package.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Monday, March 22 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-17 08:12:53 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-17 09:34:26 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -350,7 +350,10 @@ Here's a representation of the symlink and directories:
 "
   (cond
    ;;
-   ((eq type 'final-dir-at-startup) package-user-dir)
+   ((eq type 'final-dir-at-startup)
+    ;; although PEL init ensure package-user-dir ends with a "/"
+    ;; don't take any chances: ensure it does.
+    (file-name-as-directory package-user-dir))
    ;;
    ((memq type '(final-dir-now switch-dir))
     (let ((switch-dir (pel-locate-elpa)))
@@ -361,7 +364,7 @@ Here's a representation of the symlink and directories:
             (file-truename switch-dir)
           switch-dir))))
    ;;
-   ((eq type 'switched-dir-at-startup) pel--elpa-dirpath-original)
+   ((eq type 'switch-dir-at-startup) pel--elpa-dirpath-original)
    (t (error "Invalid pel-elpa-dirpath argument: %S" type))))
 
 (defun pel-elpa-attic-dirpath ()

--- a/pel-package.el
+++ b/pel-package.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Monday, March 22 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-17 09:34:26 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-17 11:41:44 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -261,13 +261,16 @@ depends on the TYPE argument, which can be one of the following symbols:
 
 - \\='final-dir-at-startup   The final directory elpa-complete, elpa-reduced,
                           elpa-complete-graphics or elpa-reduced-graphics
-                          directory used by this Emacs sessions when it
+                          directory used by this Emacs session when it
                           started.
 
 - \\='final-dir-now          The final directory elpa-complete, elpa-reduced,
                           elpa-complete-graphics or elpa-reduced-graphics
                           directory as currently identified in the file
                           system by the elpa or elpa-graphics symlink.
+                          When a symlink is used, the returned value is
+                          fully resolved and identifies the final directory
+                          target.
 
 To understand the purpose of this function you need to understand the
 way PEL organizes the `user-emacs-directory' (normally ~/.emacs.d) with
@@ -316,7 +319,7 @@ use the \"~/.emacs.d/elpa-complete\" directory that was not modified.
 It becomes important for the PEL logic to be able to identify the
 real (final) directory in some situations, and identify the location of
 the symlink (switch) in other situations.  And this must be easy to
-identify the one that the current Emacs session started with and the the
+identify the one that the current Emacs session started with and the
 final directory currently identified by the symlink that can differ from
 the one the current Emacs session is using because the PEL logic changed
 the target of the symlink to change the mode from normal to fast or vice
@@ -348,24 +351,25 @@ Here's a representation of the symlink and directories:
                  +-- elpa-reduced-graphics  |
                                             /
 "
-  (cond
-   ;;
-   ((eq type 'final-dir-at-startup)
-    ;; although PEL init ensure package-user-dir ends with a "/"
-    ;; don't take any chances: ensure it does.
-    (file-name-as-directory package-user-dir))
-   ;;
-   ((memq type '(final-dir-now switch-dir))
-    (let ((switch-dir (pel-locate-elpa)))
-      (if (eq type 'switch-dir)
-          switch-dir
-        ;; final-dir-now requested
-        (if (file-symlink-p (directory-file-name switch-dir))
-            (file-truename switch-dir)
-          switch-dir))))
-   ;;
-   ((eq type 'switch-dir-at-startup) pel--elpa-dirpath-original)
-   (t (error "Invalid pel-elpa-dirpath argument: %S" type))))
+  (file-name-as-directory
+   (cond
+    ;;
+    ((eq type 'final-dir-at-startup)
+     ;; although PEL init ensure package-user-dir ends with a "/"
+     ;; don't take any chances: ensure it does.
+     package-user-dir)
+    ;;
+    ((memq type '(final-dir-now switch-dir))
+     (let ((switch-dir (pel-locate-elpa)))
+       (if (eq type 'switch-dir)
+           switch-dir
+         ;; final-dir-now requested
+         (if (file-symlink-p (directory-file-name switch-dir))
+             (file-truename switch-dir)
+           switch-dir))))
+    ;;
+    ((eq type 'switch-dir-at-startup) pel--elpa-dirpath-original)
+    (t (error "Invalid pel-elpa-dirpath argument: %S" type)))))
 
 (defun pel-elpa-attic-dirpath ()
   "Return the absolute path of the user elpa-attic directory.

--- a/pel-package.el
+++ b/pel-package.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Monday, March 22 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-16 15:56:28 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-16 16:16:00 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -407,10 +407,9 @@ when it is requested as specified by the presence of
        (when (and (commandp symbol)
                   (progn
                     (setq cmd-name (symbol-name symbol))
-                    (and (eq t (compare-strings "pel-" nil nil
-                                                cmd-name 0 4))
-                         (not (pel-string-starts-with-p cmd-name "pel-∑"))
-                         (not (pel-string-starts-with-p cmd-name "pel-⅀")))))
+                    (and (string-prefix-p "pel-" cmd-name)
+                         (not (string-prefix-p "pel-∑" cmd-name))
+                         (not (string-prefix-p "pel-⅀" cmd-name)))))
          (push symbol symbols))))
     (nreverse symbols)))
 

--- a/pel-package.el
+++ b/pel-package.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Monday, March 22 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-16 16:16:00 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-16 16:26:29 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -455,7 +455,9 @@ Group 2 is package name.")
 Name of package is in group 1.")
 
 (defun pel--pkg-installed-by-pel (regexp &optional group extracter)
-  "Return list of package names PEL can install from Elpa compliant sites."
+  "Return list of package names PEL can install with specified mechanism.
+The installation mechanism is specified by the REGEXP expression
+and the optional GROUP number and EXTRACTER function."
   (or group (setq group 1))
   (let ((pkg-names nil)
         found

--- a/pel-package.el
+++ b/pel-package.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Monday, March 22 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-16 16:26:29 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-16 16:53:21 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -454,6 +454,15 @@ Group 2 is package name.")
   "Regexp to extract package name from a `pel-install-file' form.
 Name of package is in group 1.")
 
+(defconst pel--regexp-quelpa-pkg-name
+  "(pel-quelpa-install\\s-+(\\([-[:alnum:]]+\\)"
+  "Regexp to extract package name from a `pel-quelpa-install' form.
+Matches forms like:
+  (pel-quelpa-install (pkgname :fetcher ...))
+or multi-line forms where `pkgname' appears on the next line after indentation.
+The `\\s-+' matches any whitespace, including newlines and leading spaces.
+Group 1 captures the package symbol name.")
+
 (defun pel--pkg-installed-by-pel (regexp &optional group extracter)
   "Return list of package names PEL can install with specified mechanism.
 The installation mechanism is specified by the REGEXP expression
@@ -493,20 +502,32 @@ and the optional GROUP number and EXTRACTER function."
       (match-string 1))))
 
 (defun pel-installable-packages ()
-  "Return a list of packages PEL can install."
-  (let ((pkgs-from-elpa (sort
-                         (pel--pkg-installed-by-pel pel--regxp-pel-ensure 1)
-                         (function string<)))
+  "Return a list of 3 lists of packages PEL can install.
+The returned list has the form (ELPA QUELPA OTHERS), where:
+- ELPA   : packages installable from Elpa-compliant repositories,
+           identified by `pel-ensure-package-elpa' forms.
+- QUELPA : packages installable via quelpa from VCS sources,
+           identified by `pel-quelpa-install' forms.
+- OTHERS : the quelpa tool itself and packages installed from
+           GitHub, GitLab, or local files.
+Note: a package appearing under both ELPA and QUELPA means PEL
+uses a conditional branch to choose between sources (e.g. lispy)."
+  (let ((pkgs-from-elpa
+         (sort (pel--pkg-installed-by-pel pel--regxp-pel-ensure 1)
+               (function string<)))
+        (pkgs-from-quelpa
+         (sort (pel--pkg-installed-by-pel pel--regexp-quelpa-pkg-name 1)
+               (function string<)))
         (pkgs-others
          (sort
           (append
-           '("quelpa")                  ; uses a special method
+           '("quelpa")                  ; the quelpa tool itself
            (pel--pkg-installed-by-pel pel--regxp-from-github 1
                                       (function pel--extract-github-pkg-name))
            (pel--pkg-installed-by-pel pel--regxp-from-gitlab 2)
            (pel--pkg-installed-by-pel pel--regexp-pel-install-file 1))
           (function string<))))
-    (list pkgs-from-elpa pkgs-others)))
+    (list pkgs-from-elpa pkgs-from-quelpa pkgs-others)))        ; 3 lists
 
 ;; --
 
@@ -944,6 +965,9 @@ The function does not support printing a full report on stdout."
          (n-utils-locked    (- n-utils-all n-utils-bdeps))
          (user-options      (pel-user-options))
          (installable-pkgs  (pel-installable-packages))
+         (n-installable-elpa   (length (nth 0 installable-pkgs)))
+         (n-installable-quelpa (length (nth 1 installable-pkgs)))
+         (n-installable-others (length (nth 2 installable-pkgs)))
          (upgradable-pkgs   (pel-package-upgradable))
          (overview
           (format "\
@@ -953,7 +977,7 @@ The function does not support printing a full report on stdout."
 - %3d Utils files   stored in: %s
 - size of load-path          : %d directories
 - # pel-use-... user-options : %3d (%d are active)
-- # packages PEL can install : %d Elpa-compliant, %d others
+- # packages PEL can install : %d Elpa-compliant, %d quelpa,  %d others
 - PEL activated elpa packages: %s
 - PEL Activated utils files  : %s
 - # loaded files             : %d
@@ -983,8 +1007,9 @@ The function does not support printing a full report on stdout."
                            (lambda (x) (symbol-value x))
                            user-options))
                   ;; # package PEL can install
-                  (length (car installable-pkgs))  ; elpa compliant packages
-                  (length (cadr installable-pkgs)) ; other packages
+                  n-installable-elpa
+                  n-installable-quelpa
+                  n-installable-others
                   (pel--elpa-stats n-elpa-base ; PEL activated elpa packages
                                    n-elpa-deps
                                    n-elpa-locked)

--- a/pel-package.el
+++ b/pel-package.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Monday, March 22 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-17 12:19:05 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-17 22:28:25 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -1639,7 +1639,7 @@ The elpa-attic directory is the ~/.emacs.d/pel-elpa-attic directory."
           (copy-directory elpa-attic-pkg-dirpath
                           (file-name-as-directory used-elpa-dirpath)
                           :keep-time))
-        (push dest-dirpath load-path)
+        (add-to-list 'load-path dest-dirpath)
         (load-library (pel-as-string pkg))
         (setq installation-succeeded t)))
     installation-succeeded))

--- a/pel-package.el
+++ b/pel-package.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Monday, March 22 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-16 16:53:21 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-16 17:12:18 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -241,7 +241,7 @@ set to the path of the elpa directory or symlink if it exists.  Note
 that you can have several elpa directories if you set `package-user-dir'
 inside your init.el file.
 
-Evaluate (`pel-elpa-dirpath' \\='at-startup) to access this value.")
+Evaluate (`pel-elpa-dirpath' \\='switch-dir-at-startup) to access this value.")
 
 (defun pel-elpa-dirpath (type)
   "Return absolute path of user elpa directory or symlink as by TYPE.
@@ -253,6 +253,11 @@ depends on the TYPE argument, which can be one of the following symbols:
                           also be a symlink (and normally is once PEL has
                           setup the ability to activate the fast startup
                           mode).
+
+- \\='switch-dir-at-startup  The elpa (or elpa-graphics) directory which may
+                          also be a symlink (and normally is once PEL has
+                          setup the ability to activate the fast startup
+                          mode) seen when Emacs started.
 
 - \\='final-dir-at-startup   The final directory elpa-complete, elpa-reduced,
                           elpa-complete-graphics or elpa-reduced-graphics
@@ -344,7 +349,9 @@ Here's a representation of the symlink and directories:
                                             /
 "
   (cond
+   ;;
    ((eq type 'final-dir-at-startup) package-user-dir)
+   ;;
    ((memq type '(final-dir-now switch-dir))
     (let ((switch-dir (pel-locate-elpa)))
       (if (eq type 'switch-dir)
@@ -353,6 +360,8 @@ Here's a representation of the symlink and directories:
         (if (file-symlink-p (directory-file-name switch-dir))
             (file-truename switch-dir)
           switch-dir))))
+   ;;
+   ((eq type 'switched-dir-at-startup) pel--elpa-dirpath-original)
    (t (error "Invalid pel-elpa-dirpath argument: %S" type))))
 
 (defun pel-elpa-attic-dirpath ()
@@ -1398,7 +1407,7 @@ of their dependencies.
 The returned list contains symbols, each symbol is the name (without any
 version numbering) of the elpa package.  The list is sorted."
   (let ((activated-elpa (car (pel-activated-packages)))
-        (available-elpa (pel-elpa-packages-in-dir 'now))
+        (available-elpa (pel-elpa-packages-in-dir 'final-dir-at-startup))
         (excess-elpa    ()))
     ;; Some packages are identified by the user as used, even though PEL may
     ;; not requests it via user-options; make sure to not identify these

--- a/pel-package.el
+++ b/pel-package.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Monday, March 22 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-16 17:12:18 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-17 08:12:53 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -730,56 +730,89 @@ some PEL user-options have been turned off."
   "Compare name strings of S1 and S2 symbols."
   (string< (symbol-name s1) (symbol-name s2)))
 
+(defun pel--pkg-deps-via-package-alist (pkg)
+  "Return a flat list of transitive dependency symbols for PKG.
+Walks `package-alist' using the stable public `package-desc-reqs' API.
+This is a version-independent fallback used when neither
+`package--get-deps' nor `package--dependencies' is available.
+PKG is a symbol; the returned list does NOT include PKG itself."
+  ;; Breadth-first traversal of package-alist.
+  (let ((seen '())
+        (queue (list pkg)))
+    (while queue
+      (let ((current (pop queue)))
+        (unless (memq current seen)
+          (let ((pkg-desc (cadr (assq current package-alist))))
+            (when pkg-desc
+              (push current seen)
+              (dolist (req (package-desc-reqs pkg-desc))
+                (unless (memq (car req) seen)
+                  (push (car req) queue))))))))
+    ;; Exclude PKG itself: we report only its dependencies.
+    (delq pkg seen)))
+
 (defun pel-elpa-pkg-dependencies (pkg)
   "Return a list of package symbols that are elpa dependencies of package PKG.
 
-PKG may be a symbol or a string."
-  ;; Make sure that pkg is present, if it is not then its dependants
+PKG may be a symbol or a string.
+
+Implementation strategy by Emacs version:
+- Emacs ≤ 26 : `package--get-deps' accepts a single symbol argument.
+- Emacs 27-29: `package--get-deps' accepts a list argument (signature
+  changed in the October 2019 Emacs commit).  The post-2019 version also
+  includes PKG itself in its result; it is stripped here.
+- Emacs 30+  : `package--get-deps' was removed.  PEL uses
+  `pel--pkg-deps-via-package-alist' which performs the identical BFS
+  traversal with only the stable public APIs `package-alist' and
+  `package-desc-reqs', avoiding reliance on any changed internal
+  package.el function."
+  ;; Make sure that pkg is present, if it is not, its dependants
   ;; are not installed via that package.
   (when (locate-library (pel-as-string pkg))
     (setq pkg (pel-as-symbol pkg))
-    (if (and (require 'package nil :noerror)
-             (fboundp 'package--get-deps))
-        (condition-case err
-            (let ((pkg-arg      pkg)
-                  (dependencies ()))
-              ;; package--get-deps was modified on the October 6th 2019.
-              ;; The argument for the new version is a list.
-              (when pel-emacs-27-or-later-p
-                (setq pkg-arg (list pkg-arg)))
-              (condition-case err
-                  (setq dependencies (package--get-deps pkg-arg))
-                (error
-                 (setq dependencies nil)
-                 (display-warning
-                  'emacs-pkg-dependencies
-                  (format "\
+    (if (require 'package nil :noerror)
+        (cond
+         ;; ------------------------------------------------------------------
+         ;; Emacs ≤ 29: `package--get-deps' is available.
+         ;; The argument changed from a symbol to a list in October 2019
+         ;; (Emacs 27 era).  The post-2019 form also returns PKG itself;
+         ;; strip it for a consistent return contract.
+         ;;
+         ((fboundp 'package--get-deps)
+          (condition-case err
+              (let* ((pkg-arg      (if pel-emacs-27-or-later-p
+                                       (list pkg)
+                                     pkg))
+                     (dependencies (condition-case inner-err
+                                       (package--get-deps pkg-arg)
+                                     (error
+                                      (display-warning
+                                       'emacs-pkg-dependencies
+                                       (format "\
 Warning: %s dependencies are not identified properly: %s
 Please report the issue to the package developer
 if this is a recent version of the package."
-                          pkg-arg
-                          err))))
-              ;; package--get-deps of October 6th 2019 leaves the searched
-              ;; pkg in the list of dependencies it returns.  The old code did
-              ;; not do that. IMHO its a bug, violating the principle of least
-              ;; surprise, but it looks like the only place where it is
-              ;; invoked requires it to be included.
-              ;; Since I don't want the pkg to be listed in its dependencies,
-              ;; I remove it if it is there.
-              (when (memq pkg dependencies)
-                (delete pkg dependencies))
-              dependencies)
-          ;; error handler
-          (wrong-type-argument
-           (unless (memq pkg pel-elpa-obsolete-packages)
-             (display-warning
-              'pel-elpa-pkg-dependencies
-              (format "\
-Error extracting dependencies for %s : %s
-Is it obsolete? If so it should be added to pel-elpa-obsolete-packages."
-                      pkg err)
-              :error))
-           nil))
+                                               pkg-arg inner-err))
+                                      nil))))
+                ;; package--get-deps (post Oct 2019) includes PKG itself;
+                ;; use delq (eq-based) since pkg is a symbol.
+                (delq pkg dependencies))
+            (wrong-type-argument
+             (unless (memq pkg pel-elpa-obsolete-packages)
+               (display-warning
+                'pel-elpa-pkg-dependencies
+                (format "\
+Error extracting dependencies for %s: %s
+Is it obsolete? If so it should be added to `pel-elpa-obsolete-packages'."
+                        pkg err)
+                :error))
+             nil)))
+         ;; ------------------------------------------------------------------
+         ;; Emacs 30+: package--get-deps was removed.
+         ;; Use the stable-public-API BFS walker.
+         ;;
+         (t
+          (pel--pkg-deps-via-package-alist pkg)))
       (error "Failed loading package"))))
 
 (defun pel-activated-packages (&optional without-dependants ignore-restriction)

--- a/pel-package.el
+++ b/pel-package.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Monday, March 22 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-17 11:41:44 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-17 12:19:05 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -191,7 +191,7 @@ directory into a symlink that points to a directory named
 mode is used and Emacs is a GUI process.
 
 It's possible that PEL is used with a init.el file that has not yet been
-populated with the proper code and pel-package-user-dir-original'
+populated with the proper code and `pel-package-user-dir-original'
 variable does not exist. In that case the function report a warning and
 tries to locate the elpa directory the standard way using the standard
 `package-user-dir' or by building its path via the

--- a/pel-package.el
+++ b/pel-package.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Monday, March 22 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-15 13:23:02 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-16 14:31:44 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -87,15 +87,9 @@
 ;; install files from the elpa attic, allowing quick restoration of disabled
 ;; elpa package without having to access the Internet.
 ;;
-;;  The code identifies you local Elpa and utils directories and their attic
-;;  counterparts, normally stored inside the ~/.emacs.d directory or the
-;;  equivalent.  The location of those directories when Emacs starts and load
-;;  this file is first stored inside the `pel--elpa-dirpath-original' defconst.
-;;  That value is returned by (`pel-elpa-dirpath' 'at-startup).  The current
-;;  value is returned by (`pel-elpa-dirpath 'now).
 ;;
 ;;   - `pel-elpa-dirpath'
-;;     - `pel-elpa-locate'
+;;     - `pel-locate-elpa'
 ;;
 ;;   - `pel-elpa-attic-dirpath'
 ;;   - `pel-utils-dirpath'
@@ -172,8 +166,6 @@
 ;;; Code:
 ;;
 
-;; [:todo 2024-01-05, by Pierre Rouleau: better handle unbound
-;;                    pel-package-user-dir-original value.]
 (defun pel-locate-elpa ()
   "Return the absolute path of the local Elpa directory (or symlink).
 
@@ -181,7 +173,7 @@ PEL early-init.el and init.el file update the dynamic value of the Emacs
 `package-user-dir' user-option to ensure that the value used by
 package.el:
 
-- correspond to what is required when PEL operates in dual tty/graphics
+- corresponds to what is required when PEL operates in dual tty/graphics
   setup environment for Emacs running in terminal or graphics mode,
 - is a true directory name, not the symlink that may point to it.
 
@@ -203,13 +195,11 @@ populated with the proper code and pel-package-user-dir-original'
 variable does not exist. In that case the function report a warning and
 tries to locate the elpa directory the standard way using the standard
 `package-user-dir' or by building its path via the
-`user-emacs-directory' value.  If you get the warning you should update
-your init.el file (and possibly the early-init.el) by using what PEL provides
-in the example/init directory.
+`user-emacs-directory' value.
 
-In the remote possibility that `package-user-dir' is not bound
-then the \"elpa\" sub-directory of the directory identified by
-the variable `user-emacs-directory' is used."
+If you get the warning you should update your init.el file (and possibly
+the early-init.el) by using what PEL provides in the example/init
+directory."
   (file-name-as-directory
    (if (bound-and-true-p pel-package-user-dir-original)
        (expand-file-name pel-package-user-dir-original)
@@ -217,8 +207,10 @@ the variable `user-emacs-directory' is used."
      ;; `pel-package-user-dir-original' does not exist!
      ;; You are not using a PEL compliant init.el file!
      ;; But warn only at load or run time, not at compile time
+     ;; and not when running ERT based tests.
      (unless (or (bound-and-true-p byte-compile-current-file)
                  (bound-and-true-p comp-native-compiling)
+                 (bound-and-true-p ert--test-execution-info)
                  (getenv "EMACS_TEST_VERBOSE"))
        (let ((errmsg
               (format "⚠️  Emacs init.el does not comply with PEL requirements!
@@ -251,13 +243,117 @@ inside your init.el file.
 
 Evaluate (`pel-elpa-dirpath' \\='at-startup) to access this value.")
 
-(defun pel-elpa-dirpath (moment)
-  "Return absolute path of user elpa directory or symlink at specific MOMENT.
-MOMENT can be \\='at-startup or \\='now."
+(defun pel-elpa-dirpath (type)
+  "Return absolute path of user elpa directory or symlink as by TYPE.
+
+The returned string always ends with a / indicating a directory and
+depends on the TYPE argument, which can be one of the following symbols:
+
+- \\='switch-dir             The elpa (or elpa-graphics) directory which may
+                          also be a symlink (and normally is once PEL has
+                          setup the ability to activate the fast startup
+                          mode).
+
+- \\='final-dir-at-startup   The final directory elpa-complete, elpa-reduced,
+                          elpa-complete-graphics or elpa-reduced-graphics
+                          directory used by this Emacs sessions when it
+                          started.
+
+- \\='final-dir-now          The final directory elpa-complete, elpa-reduced,
+                          elpa-complete-graphics or elpa-reduced-graphics
+                          directory as currently identified in the file
+                          system by the elpa or elpa-graphics symlink.
+
+To understand the purpose of this function you need to understand the
+way PEL organizes the `user-emacs-directory' (normally ~/.emacs.d) with
+respect to the way it stores the Elpa-compliant packages in order to
+support two different features:
+
+- Feature 1: PEL fast startup mode
+- Feature 2: PEL dual-mode: dual tty/graphics customization mode
+
+The Elpa compliant packages are normally stored inside a directory named
+\"elpa\".
+
+When PEL fast startup mode is activated, PEL renames the \"elpa\"
+directory to \"elpa-complete\" and creates a symbolic link named
+\"elpa\" that points to \"elpa-complete\".  After, PEL creates a
+\"elpa-reduced\" directory to store all multi-directory packages used in
+\"elpa-complete\" and then creates a \"pel-bundle\" package that holds
+the Emacs Lisp files of all single-directory packages in the current
+content of the \"elpa-complete\" directory.  This reduces dramatically
+the number of package directories located inside the \"elpa-reduced\"
+compared to the number stored in \"elpa-complete\" directory and
+significantly speeds up Emacs startup time.
+
+When PEL dual-mode is activated, PEL supports two different Emacs
+customization files and two sets of Elpa directories: one set used by
+Emacs running in terminal mode and another set for Emacs running in
+graphics mode. This way packages used for Emacs in graphics mode are not
+stored in the Elpa directories used by Emacs running in terminal mode
+and vice versa.  This further improves Emacs startup speed.
+
+PEL early-init.el and init.el provide logic to setup important variables
+in PEL and Emacs package management: `package-user-dir' and
+`pel-package-user-dir-original'.
+
+It's also important to understand that PEL design allows the use of
+multiple independent Emacs processes.  One Emacs process might be
+started while PEL is setup for the normal operation mode.  Later another
+Emacs session may activate the PEL fast-startup mode.  When doing that
+the PEL setup code changes the target of the \"~/.emacs.d/elpa symlink\"
+to point to \"~/.emacs.d/elpa-reduced\" directory after updating the
+content of the \"elpa-reduced\" directory.  This will affect the
+behaviour of all Emacs processes started from that moment but does *not*
+affect the Emacs sessions already running because these Emacs sessions
+use the \"~/.emacs.d/elpa-complete\" directory that was not modified.
+
+It becomes important for the PEL logic to be able to identify the
+real (final) directory in some situations, and identify the location of
+the symlink (switch) in other situations.  And this must be easy to
+identify the one that the current Emacs session started with and the the
+final directory currently identified by the symlink that can differ from
+the one the current Emacs session is using because the PEL logic changed
+the target of the symlink to change the mode from normal to fast or vice
+versa.
+
+Here's a representation of the symlink and directories:
+
+  switch-dir          final-dir
+   |                      |
+   |                      |
+   v                      v
+                                            \\
+                 +-- elpa-complete          |
+                 |                          |
+                 |                          |
+  elpa --------->+                          |  For Emacs:
+                 |                          |  - in terminal mode
+                 |                          |  - in graphics mode when
+                 +-- elpa-reduced           |    when dual-mode is not
+                                            /    used.
+
+                                            \\
+                 +-- elpa-complete-graphics |
+                 |                          |
+                 |                          |
+  elpa-graphics->+                          |  For Emacs in graphics
+                 |                          |  mode when dual-mode is
+                 |                          |  used.
+                 +-- elpa-reduced-graphics  |
+                                            /
+"
   (cond
-   ((eq moment 'at-startup) pel--elpa-dirpath-original)
-   ((eq moment 'now) (pel-locate-elpa))
-   (t (error "Invalid pel-elpa-dirpath argument: %S" moment))))
+   ((eq type 'final-dir-at-startup) package-user-dir)
+   ((memq type '(final-dir-now switch-dir))
+    (let ((switch-dir (pel-locate-elpa)))
+      (if (eq type 'switch-dir)
+          switch-dir
+        ;; final-dir-now requested
+        (if (file-symlink-p (directory-file-name switch-dir))
+            (file-truename switch-dir)
+          switch-dir))))
+   (t (error "Invalid pel-elpa-dirpath argument: %S" type))))
 
 (defun pel-elpa-attic-dirpath ()
   "Return the absolute path of the user elpa-attic directory.
@@ -1112,25 +1208,46 @@ Return the a cons of 2 lists:
 
 ;; --
 
+(defun pel-pkgs-sorted-by-version (pkg-dirs)
+  "Return a list of ELPA PKG-DIRS sorted by their version.
+The function assumes that:
+- the last hyphen in the name separates the package name from the package
+  version number,
+- every package has the same name,
+- every package number uses the same style of version number: digits
+  representing a YYYYMMDD.HHMMSS sequence or Major.minor or equivalent
+  like 12.23, 12.44, etc..."
+  (sort (copy-sequence pkg-dirs)
+        (lambda (a b)
+          (let ((fn-a (file-name-nondirectory a))
+                (fn-b (file-name-nondirectory b)))
+            (let ((v-a (and (string-match "-\\([0-9.]+\\)$" fn-a) (match-string 1 fn-a)))
+                  (v-b (and (string-match "-\\([0-9.]+\\)$" fn-b) (match-string 1 fn-b))))
+              (version< v-a v-b))))))
+
 (defun pel-elpa-dirs-for (pkg &optional in-attic)
-  "Return a list of all directories for specified package PKG.
+  "Return a list of directory names for specified package PKG.
 
-PKG may be a symbol or a string.
+PKG may be a symbol or a string identifying a package name.
+Something like \\='seq, \"seq\", \\='lispy or \"lispy\".
 
-By default, return package directory names available in the elpa
-directory, but if the IN-ATTIC argument is non-nil, return
-packages in the elpa-attic directory. Each directory is specified
-with full path.
+Each returned string is the name of a directory with full path.
+Each string does not end with a slash character.
 
 The returned list of directory paths is sorted in alphabetical
 order.  For several versions of a given package the most recent
-is placed last."
-  (directory-files (if in-attic
-                       (pel-elpa-attic-dirpath)
-                     package-user-dir)
-                   :full-path
-                   (format "\\`%s-[0-9-.]+\\'"
-                           (regexp-quote (pel-as-string pkg)))))
+is placed last: they are sorted by version numbers.
+
+By default, return package directory names available in the elpa
+directory, but if the IN-ATTIC argument is non-nil, return
+packages present in the elpa-attic directory."
+  (pel-pkgs-sorted-by-version
+   (directory-files (if in-attic
+                        (pel-elpa-attic-dirpath)
+                      package-user-dir)
+                    :full-path
+                    (format "\\`%s-[0-9-.]+\\'"
+                            (regexp-quote (pel-as-string pkg))))))
 
 (defun pel-move-to-dir (file dir)
   "Move FILE to directory DIR.
@@ -1228,7 +1345,7 @@ Return the number of symbols that were removed from the
     ;; restore superword-mode to what it was before.
     (superword-mode (if original-superword-mode-state 1 -1))))
 
-(defun pel-elpa-packages-in-dir (moment)
+(defun pel-elpa-packages-in-dir (type)
   "Return a list of symbol for all packages present in local Elpa directory.
 
 The function search the directory identified by `pel-elpa-dirpath'.
@@ -1239,7 +1356,7 @@ The returned list contains only one symbol identifying the package for each
 version of that package.
 The list of package symbols is sorted by symbol names."
   (let ((elpa-pkg-dir-names  (directory-files
-                              (pel-elpa-dirpath moment) nil ".+[0-9-.]+\\'"))
+                              (pel-elpa-dirpath type) nil ".+[0-9-.]+\\'"))
         (elpa-pkg-names ()))
     (dolist (dir-name elpa-pkg-dir-names)
       (when (eq 0 (string-match "\\`\\([^ ]+\\)-[0-9-.]+\\'" dir-name))
@@ -1410,7 +1527,7 @@ intention by typing 'y' to its prompt.
 from: %s
 to  : %s :\n\n"
                              verb-moved
-                             (pel-elpa-dirpath 'now)
+                             (pel-elpa-dirpath 'final-dir-at-startup)
                              (pel-elpa-attic-dirpath)))
              (setq n 0)
              (dolist (pkgdir moved-elpa-dirs)
@@ -1437,7 +1554,7 @@ The elpa-attic directory is the ~/.emacs.d/pel-elpa-attic directory."
   (let ((elpa-attic-pkg-dirpath (car-safe
                                  (last (pel-elpa-dirs-for pkg :in-attic))))
         (installation-succeeded nil)
-        (used-elpa-dirpath (pel-elpa-dirpath 'now)))
+        (used-elpa-dirpath (pel-elpa-dirpath 'final-dir-at-startup)))
     (when elpa-attic-pkg-dirpath
       (let ((dest-dirpath
              (expand-file-name (file-name-nondirectory

--- a/pel-setup-27.el
+++ b/pel-setup-27.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-16 15:06:42 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-17 18:21:56 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -122,15 +122,29 @@ FOR-GRAPHICS is:
   (if (and (require 'package nil :noerror)
            (fboundp 'package-quickstart-refresh)
            (boundp 'package-quickstart-file))
-      (let* ((package-user-dir        (pel-elpa-name dirpath for-graphics))
+      ;; If package-quickstart-refresh errors, leave a clear diagnostic and do
+      ;; not leave a half-written quickstart file. Wrap with condition-case
+      ;; and remove the file on failure.
+      (let* ((package-user-dir (pel-elpa-name dirpath for-graphics))
              (package-quickstart-file (pel-elpa-name package-quickstart-file for-graphics))
-             (package-alist           (pel-elpa-package-alist-of-dir package-user-dir)))
-        (package-quickstart-refresh)
-        ;; Byte-compile it if requested, otherwise remove its .elc
-        (pel-compile-file-if package-quickstart-file
-                             (and pel-compile-package-quickstart
-                                  (pel-remove-no-byte-compile-in
-                                   package-quickstart-file))))
+             (package-alist (pel-elpa-package-alist-of-dir package-user-dir)))
+        (condition-case err
+            (progn
+              (package-quickstart-refresh)
+              ;; Byte-compile it if requested, otherwise remove its .elc
+              (pel-compile-file-if
+               package-quickstart-file
+               (and pel-compile-package-quickstart
+                    (pel-remove-no-byte-compile-in package-quickstart-file))))
+          (error
+           (when (file-exists-p package-quickstart-file)
+             (ignore-errors (delete-file package-quickstart-file))
+             (ignore-errors (delete-file (concat package-quickstart-file "c"))))
+           (signal 'error
+                   (list (format "Failed generating package-quickstart for %s (%s): %s"
+                                 package-user-dir
+                                 (if for-graphics "graphics" "tty")
+                                 (error-message-string err)))))))
     ;; report any error
     (error "Failed accessing package-quickstart")))
 

--- a/pel-setup-27.el
+++ b/pel-setup-27.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-15 11:19:29 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-16 15:06:42 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -111,8 +111,8 @@
 
 DIRPATH is the path of a ELpa-compliant directory used.
 Normally that's the elpa directory inside the user-emacs-directory but
-that can be the elpa-reduced directory for fast startup or then ones
-for graphics mode when the dual mode is used.
+that can be the elpa-reduced directory for fast startup or the one for
+graphics mode when the dual mode is used.
 
 FOR-GRAPHICS is:
 - t when setting package quickstart for Emacs running in graphics mode and
@@ -197,7 +197,7 @@ Available for Emacs 27 and later only."
       (message "Activating package quickstart...")
       (pel--set-package-quickstart-in-early-init t)
       (let ((elpa-dpath (pel-sibling-dirpath
-                         (pel-elpa-dirpath 'at-startup)
+                         (pel-elpa-dirpath 'switch-dir)
                          (if (eq startup-mode 'fast)
                              "elpa-reduced"
                            (if (file-exists-p (locate-user-emacs-file "elpa-complete"))

--- a/pel-setup-27.el
+++ b/pel-setup-27.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-03-26 22:55:47 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-15 11:19:29 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -197,7 +197,7 @@ Available for Emacs 27 and later only."
       (message "Activating package quickstart...")
       (pel--set-package-quickstart-in-early-init t)
       (let ((elpa-dpath (pel-sibling-dirpath
-                         pel-elpa-dirpath
+                         (pel-elpa-dirpath 'at-startup)
                          (if (eq startup-mode 'fast)
                              "elpa-reduced"
                            (if (file-exists-p (locate-user-emacs-file "elpa-complete"))

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-17 12:28:36 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-18 10:13:31 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -78,7 +78,7 @@
 (require 'pel-elpa)            ; use: `pel-elpa-name'
 (require 'pel-package)         ; use: `pel-elpa-dirpath'
 
-(eval-when-compile (require 'subr-x)) ; use: `string-join'
+(require 'subr-x)              ; use: `string-join'
 
 ;;; --------------------------------------------------------------------------
 ;;; Code:
@@ -278,7 +278,7 @@ The FOR-GRAPHICS argument identifies the setup forced for independent graphics."
       "dual-environment graphics mode"
     (if pel-detected-dual-environment-in-init-p
         "dual-environment terminal/tty mode"
-      "single custom-file modes")))
+      "single custom-file mode")))
 
 (defun pel-fast-setup-met-criteria ()
   "Check if the setup meets fast startup settings.
@@ -299,8 +299,8 @@ startup if all tests pass."
     (pel+= test-count 1)
     (if (pel-in-fast-startup-p)
         (pel-push-fmt met-criteria
-            "Identified as fast startup by function `pel-in-fast-startup'")
-      (pel-push-fmt issues "The `pel-in-fast-startup' is not set."))
+            "Identified as fast startup by function `pel-in-fast-startup-p'")
+      (pel-push-fmt issues "The `pel-running-in-fast-startup-p' is not set."))
     ;;
     (pel+= test-count 1)
     (if (file-exists-p pel-fast-startup-init-fname)

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-14 10:39:26 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-15 11:20:44 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -301,10 +301,12 @@ startup if all tests pass."
                              '(nil t)
                            '(nil)))
       (let* ((mode-description (pel-setup-mode-description for-graphic))
-             (elpa-dirpath (pel-elpa-name pel-elpa-dirpath for-graphic))
-             (elpa-reduced-dirpath (pel-elpa-name (pel-sibling-dirpath
-                                                         elpa-dirpath "elpa-reduced")
-                                                        for-graphic)))
+             (elpa-dirpath (pel-elpa-name (pel-elpa-dirpath 'at-startup)
+                                          for-graphic))
+             (elpa-reduced-dirpath (pel-elpa-name
+                                    (pel-sibling-dirpath
+                                     elpa-dirpath "elpa-reduced")
+                                    for-graphic)))
         (pel+= test-count 1)
         (if (pel-same-fname-p (directory-file-name elpa-dirpath)
                               elpa-reduced-dirpath)

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-15 11:20:44 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-16 14:55:29 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -301,7 +301,7 @@ startup if all tests pass."
                              '(nil t)
                            '(nil)))
       (let* ((mode-description (pel-setup-mode-description for-graphic))
-             (elpa-dirpath (pel-elpa-name (pel-elpa-dirpath 'at-startup)
+             (elpa-dirpath (pel-elpa-name (pel-elpa-dirpath 'switch-dir)
                                           for-graphic))
              (elpa-reduced-dirpath (pel-elpa-name
                                     (pel-sibling-dirpath

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-16 14:55:29 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-17 12:28:36 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -136,9 +136,14 @@ Return nil if all is OK."
    Please update your init.el file.
    Use the pel/example/init/init.el as template."
             pel-init-file-version pel--expected-init-file-version))
+      ;; `pel-init-file-version' is not bound at all: the init.el file does
+      ;; not define it, so it was not prepared from the PEL template
+      ;; or is using an old one.
       (pel-push-fmt problems
           "Invalid init.el file (%s): not ready for PEL startup management.
-   Use the pel/example/init/init.el as template." user-init-file))
+   It must define `pel-init-file-version' set to \"%s\".
+   Use the pel/example/init/init.el as template."
+        user-init-file pel--expected-init-file-version))
     ;;
     (when pel-emacs-27-or-later-p
       (if (file-exists-p (locate-user-emacs-file "early-init.el"))
@@ -151,16 +156,23 @@ Return nil if all is OK."
    Use the pel/example/init/early-init.el as template."
                   pel-early-init-file-version
                   pel--expected-early-init-file-version))
+            ;; `pel-early-init-file-version' is not bound at all: the
+            ;; early-init.el file was not prepared from the PEL template
+            ;; or is using an old one.
             (pel-push-fmt problems
                 "Invalid early-init.el file (%searly-init.el): not ready for PEL startup management.
+   It must define `pel-early-init-file-version' set to \"%s\".
    Use the pel/example/init/early-init.el as template."
-              (file-name-parent-directory user-init-file)))
+              (file-name-parent-directory user-init-file)
+              pel--expected-early-init-file-version))
 
         (when early-init-must-exist
           (pel-push-fmt problems
               "This feature requires a PEL compatible early-init.el file
+   (with `pel-early-init-file-version' set to \"%s\")
    inside %s and that is missing.  Create one, using
    pel/example/init/early-init.el as template."
+            pel--expected-early-init-file-version
             (file-name-parent-directory user-init-file)))))
     ;;
     ;; The next check cannot be performed when quickstart is used because in

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-17 21:41:44 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-17 22:19:27 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -883,7 +883,7 @@ symlink/realpath double entries.\"
 \(defun pel-fast-startup-init (&optional force-graphics using-package-quickstart)
   \"Setup data to support the fast-startup mode.
 
-- #1: Add pkg/version of the dependencies of packages whose code has been been
+- #1: Add pkg/version of the dependencies of packages whose code has been
       bundled into elpa-reduced/pel-bundle *pseudo-package* to
       `package--builtin-versions' to prevent their downloads.
 - #2: For Emacs >= 27, when package-quickstart is used,  an extra step is

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-17 18:14:08 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-17 21:41:44 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -852,19 +852,20 @@ and has extra code specified in EXTRA-CODE."
 
 (defun pel--add-to-load-path-once (dir)
   \"Add directory DIR to `load-path' if DIR is not already inside it.
-Prevent multiple insertion by literal string and by truename
-to avoid symlink/realpath double entries.\"
-  ;; load-path directories do not end with /
+Prevent multiple insertion by literal string and by truename to avoid
+symlink/realpath double entries.\"
   (let* ((norm (directory-file-name (expand-file-name dir)))
-         (norm-truename (ignore-errors (file-truename norm))))
-    (unless (seq-some
-             (lambda (p)
-               (let* ((p0 (directory-file-name (expand-file-name p)))
-                      (pt (ignore-errors (file-truename p0))))
-                 (or (string= p0 norm)
-                     (and norm-truename pt (string= pt norm-truename)))))
-             load-path)
+         (norm-truename (ignore-errors (file-truename norm)))
+         (found nil))
+    (dolist (p load-path)
+      (let* ((p0 (directory-file-name (expand-file-name p)))
+             (pt (ignore-errors (file-truename p0))))
+        (when (or (string= p0 norm)
+                  (and norm-truename pt (string= pt norm-truename)))
+          (setq found t))))
+    (unless found
       (add-to-list 'load-path norm))))
+
 
 ;; ----
 \(defvar pel-running-in-fast-startup-p nil)
@@ -1214,7 +1215,7 @@ Please report this internal code error to project maintainer!"
       (format "\
 ;; step 2: (only for Emacs >= 27)
   (when using-package-quickstart
-      (pel--add-to-load-path-once 'load-path
+      (pel--add-to-load-path-once
                    (format \"%s\"
                            (if force-graphics \"-graphics\" \"\"))))"
               safe-path))))

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-14 16:37:36 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-15 11:26:32 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -406,12 +406,13 @@ slash) or in file name (without the terminating slash) format."
 Return nil if no problems found: all is OK, ready to use Emacs in
 independent environments for terminal and graphics mode."
   (require 'cus-edit)                   ; use: `custom-file'`
-  (let* ((custom-fname    (pel-elpa-name custom-file nil))
+  (let* ((used-elpa-dirpath (pel-elpa-dirpath 'at-startup))
+         (custom-fname    (pel-elpa-name custom-file nil))
          (custom-fname-g  (pel-elpa-name custom-file :for-graphics))
-         (elpa-dp         (pel-elpa-name pel-elpa-dirpath nil))
+         (elpa-dp         (pel-elpa-name used-elpa-dirpath nil))
          (elpa-dn         (directory-file-name elpa-dp))
          (elpa-dn-g       (pel-elpa-name elpa-dn :for-graphics))
-         (elpa-cmplt-dn   (pel-sibling-dirname pel-elpa-dirpath "elpa-complete"))
+         (elpa-cmplt-dn   (pel-sibling-dirname used-elpa-dirpath "elpa-complete"))
          (elpa-cmplt-dn-g (pel-elpa-name elpa-cmplt-dn :for-graphics))
          (utils-dp        (pel-elpa-name (pel-utils-dirpath) nil))
          (utils-dp-g      (pel-elpa-name (pel-utils-dirpath) :for-graphics))
@@ -500,12 +501,13 @@ Return a list of performed actions (in reverse order of execution)."
 
 Utility function.  If REASON-MSG is specified include that message on error."
   (require 'cus-edit)                   ; use: `custom-file'`
-  (let* ((custom-fn       (pel-elpa-name custom-file nil))
+  (let* ((used-elpa-dirpath (pel-elpa-dirpath 'at-startup))
+         (custom-fn       (pel-elpa-name custom-file nil))
          (custom-fn-g     (pel-elpa-name custom-file :for-graphics))
-         (elpa-dp         (pel-elpa-name pel-elpa-dirpath nil))
+         (elpa-dp         (pel-elpa-name used-elpa-dirpath nil))
          (elpa-dn         (directory-file-name elpa-dp))
          (elpa-dn-g       (pel-elpa-name elpa-dn :for-graphics))
-         (elpa-cmplt-dn   (pel-sibling-dirname pel-elpa-dirpath "elpa-complete"))
+         (elpa-cmplt-dn   (pel-sibling-dirname used-elpa-dirpath "elpa-complete"))
          (elpa-cmplt-dn-g (pel-elpa-name elpa-cmplt-dn :for-graphics))
          (utils-dn        (pel-elpa-name (directory-file-name (pel-utils-dirpath))
                                          nil))
@@ -686,9 +688,10 @@ There are inconsistencies in the PEL dual environment setup.
                 like \"elpa-complete\" or \"elpa-reduced\".
 - FOR-GRAPHICS: non-nil when dual environment is set and Emacs runs in
 graphic mode."
-  (let ((adj (lambda (fn) (pel-elpa-name fn for-graphics))))
-    (pel-point-symlink-to (λc adj pel-elpa-dirpath)
-                          (λc adj (pel-sibling-dirpath pel-elpa-dirpath name)))))
+  (let* ((used-elpa-dirpath (pel-elpa-dirpath 'at-startup))
+         (adj (lambda (fn) (pel-elpa-name fn for-graphics))))
+    (pel-point-symlink-to (λc adj used-elpa-dirpath)
+                          (λc adj (pel-sibling-dirpath used-elpa-dirpath name)))))
 
 (defun pel-switch-to-elpa-complete (for-graphics)
   "Change elpa symlink to the elpa-complete sub-directory.
@@ -1143,13 +1146,14 @@ GUI         No              nil
 GUI         Yes             t
 
 It must be non-nil when Emacs runs in GUI mode and PEL uses the dual-mode."
-  (let (;; define closures used to reduce visual clutter
-        (adj          (lambda (fn) (pel-elpa-name fn for-graphics))) ; adjust for graphics
-        (elpa-sibling (lambda (dp) (pel-sibling-dirpath pel-elpa-dirpath dp)))
-        (step-count 0)
-        (cd-original default-directory))
+  (let* (;; define closures used to reduce visual clutter
+         (used-elpa-dirpath (pel-elpa-dirpath 'at-startup))
+         (adj          (lambda (fn) (pel-elpa-name fn for-graphics))) ; adjust for graphics
+         (elpa-sibling (lambda (dp) (pel-sibling-dirpath used-elpa-dirpath dp)))
+         (step-count 0)
+         (cd-original default-directory))
     (condition-case-unless-debug err
-        (let* ((elpa-dp-adj      (λc adj pel-elpa-dirpath))
+        (let* ((elpa-dp-adj      (λc adj used-elpa-dirpath))
                (elpa-reduced-dp  (λc adj (λc elpa-sibling "elpa-reduced")))
                (elpa-complete-dp (λc adj (λc elpa-sibling "elpa-complete")))
                (bundle-dp        (λc elpa-sibling "pel-bundle"))
@@ -1166,7 +1170,7 @@ It must be non-nil when Emacs runs in GUI mode and PEL uses the dual-mode."
           (pel-prepend-to actions (pel--prepare-main-elpa-dir for-graphics))
           (pel+= step-count 1)          ; STEP 1
           ;;
-          (pel--validate-elpa-symlink pel-elpa-dirpath for-graphics)
+          (pel--validate-elpa-symlink used-elpa-dirpath for-graphics)
           (pel+= step-count 1)          ; STEP 2
           ;;
           ;; The pel-bundle directory should not exists.  That's a
@@ -1385,7 +1389,7 @@ is only one or when its for the terminal (TTY) mode."
     (require 'pel-setup-27)
     (pel--setup-early-init pel-support-package-quickstart)
     (if pel-support-package-quickstart
-        (pel--create-package-quickstart pel-elpa-dirpath for-graphics)
+        (pel--create-package-quickstart (pel-elpa-dirpath 'at-startup) for-graphics)
       (pel--remove-package-quickstart-files for-graphics))))
 
 ;;-pel-autoload

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-17 22:19:27 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-18 10:10:27 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -268,6 +268,7 @@
 ;;                             ;      `pel-startup-mode'
 ;;                             ;      `pel-prompt-with-quickstart-state'
 ;;                             ;      `pel-push-fmt'
+(require 'subr-x)              ; use: `string-empty-p'
 
 ;; Then following functions are defined in pel-setup-27, which is
 ;; only used in Emacs >= 27.
@@ -911,7 +912,7 @@ Return the pkg/version alist.\"
 ;; This is needed because in PEL fast-startup mode all external
 ;; packages have already been downloaded but they are not visible to
 ;; package.el logic at this point because the packages have been bundled
-;; together inside the elpa-reduce/pel-bundle *pseudo-package*.
+;; together inside the elpa-reduced/pel-bundle *pseudo-package*.
 
 \(defun pel--pct (_packages)
   \"Filter packages to prevent downloads.\"
@@ -1357,7 +1358,7 @@ It must be non-nil when Emacs runs in GUI mode and PEL uses the dual-mode."
           ;; pass whether its invoked for graphics mode and whether it's
           ;; called from early-init.
           ;;
-          ;; The `pel-fast-startup-init' function is s called by early-init
+          ;; The `pel-fast-startup-init' function is called by early-init
           ;; for Emacs ≥ 27, and called by init.el for earlier versions of
           ;; Emacs.  in both cases to add the (package
           ;; version) dependencies to simulate builtins by adding them to the

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-17 11:25:32 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-17 12:35:16 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -820,31 +820,14 @@ Return a (ACTIVATE . byte-compile result) cons cell."
                                       (locate-library "pel_keys"))
                                      ".el")))))
 
-(defun pel-setup-fast-startup-init (fname deps-pkg-versions-alist extra-code)
-  "Write Emacs Lisp code to add the DEPS-PKG-VERSIONS-ALIST to Emacs in FNAME.
+(defun pel-setup-fast-startup-init-text (deps-pkg-versions-alist extra-code)
+  "Return the Elisp code for the pel-fast-startup-init.el file.
 
-- FNAME: string.  Name of the file where the code of the function
-  `pel-fast-startup-init' is written.
-
-The function `pel-fast-startup-init' adds each entry of
-DEPS-PKG-VERSIONS-ALIST to Emacs `package--builtin-versions' and adds
-some EXTRA-CODE.
-
-- DEPS-PKG-VERSIONS-ALIST: list of package dependencies gathered from the
-  various X-pkg.el files for each package X whose code was placed in the
-  elpa-reduced/pel-bundle *pseudo-package* that was not already part of
-  the `package--builtin-versions' list.
-
-By adding those package/version inside the `package--builtin-versions'
-list we ensure that Emacs package.el logic will not attempt to download
-these packages.  We don't need Emacs to download them because they have
-already been downloaded when Emacs was in normal startup mode.  The
-DEPS-PKG-VERSIONS-ALIST list was originally returned by the function
-`pel-elpa-disable-pkg-deps-in'."
-  (with-temp-file fname
-    (erase-buffer)
-    (goto-char (point-min))
-    (insert (format "\
+This file is required when PEL uses the fast startup mode.
+The file is created for the packages identified in DEPS-PKG-VERSIONS-ALIST
+and has extra code specified in EXTRA-CODE."
+  ;;
+  (format "\
 ;;; Setup Emacs for PEL fast startup.  -*- lexical-binding: t; -*-
 ;;; DO NOT EDIT! It will be overwritten next time pel-setup-fast is executed!
 ;;;
@@ -939,8 +922,35 @@ Return the pkg/version alist.\"
 
 ;; ---------------------------------------------------------------------------
 
-" deps-pkg-versions-alist extra-code))))
+" deps-pkg-versions-alist extra-code))
 
+(defun pel-setup-fast-startup-init (fname deps-pkg-versions-alist extra-code)
+  "Write Emacs Lisp code to add the DEPS-PKG-VERSIONS-ALIST to Emacs in FNAME.
+
+- FNAME: string.  Name of the file where the code of the function
+  `pel-fast-startup-init' is written.
+
+The function `pel-fast-startup-init' adds each entry of
+DEPS-PKG-VERSIONS-ALIST to Emacs `package--builtin-versions' and adds
+some EXTRA-CODE.
+
+- DEPS-PKG-VERSIONS-ALIST: list of package dependencies gathered from the
+  various X-pkg.el files for each package X whose code was placed in the
+  elpa-reduced/pel-bundle *pseudo-package* that was not already part of
+  the `package--builtin-versions' list.
+
+By adding those package/version inside the `package--builtin-versions'
+list we ensure that Emacs package.el logic will not attempt to download
+these packages.  We don't need Emacs to download them because they have
+already been downloaded when Emacs was in normal startup mode.  The
+DEPS-PKG-VERSIONS-ALIST list was originally returned by the function
+`pel-elpa-disable-pkg-deps-in'."
+  (with-temp-file fname
+    (erase-buffer)
+    (goto-char (point-min))
+    (insert (pel-setup-fast-startup-init-text
+             deps-pkg-versions-alist
+             extra-code))))
 
 ;; --
 
@@ -1420,9 +1430,9 @@ Failed fast startup setup for %s after %d of %d steps: %s
     (user-error "PEL currently is not able to switch to fast startup mode when
   package quickstart is used and Emacs is running in graphic mode.
   Use Emacs running in terminal mode or turn package quickstart off
-  to execute this command.  Once the switch is completed, PEL can
-  run in fast startup mode with package startup active in graphic mode.
-  Sorry for the inconvenience"))
+  (with “M-x pel-setup-no-quickstart) to execute this command.
+  Once the switch is completed, PEL can run in fast startup mode with package
+  startup active in graphic mode. Sorry for the inconvenience"))
    ;;
    (t
     (when (y-or-n-p (pel-prompt-with-quickstart-state
@@ -1478,7 +1488,7 @@ is only one or when its for the terminal (TTY) mode."
     (user-error "PEL currently is not able to restore from fast startup mode when
   package quickstart is used and Emacs is running in graphic mode.
   Use Emacs running in terminal mode or turn package quickstart off
-  to execute this command.
+  (with “M-x pel-setup-no-quickstart) to execute this command.
   Sorry for the inconvenience"))
    (t
     (when (y-or-n-p (pel-prompt-with-quickstart-state

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-17 12:35:16 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-17 18:14:08 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -714,6 +714,15 @@ graphic mode."
                        extra-data include-package-version
                        generate-full))
 
+(defconst pel--auto-load-adder-code
+  "  (let* ((__dir (directory-file-name
+                    (file-name-directory (or load-file-name buffer-file-name)))))
+       (if (fboundp 'pel--add-to-load-path-once)
+           (pel--add-to-load-path-once __dir)
+         (add-to-list 'load-path __dir)))"
+
+  "Elisp Code that adds a package to load path.")
+
 (defun pel-generate-autoload-file-for (dir)
   "Prepare (compile + autoload) all files in directory DIR.
 Return the complete name of the generated autoload file."
@@ -728,20 +737,19 @@ Return the complete name of the generated autoload file."
           (condition-case-unless-debug err
               (progn
                 (when (fboundp 'loaddefs-generate)
-                  (loaddefs-generate (list dir)
-                                     output-file
-                                     nil
-                                     ;; code to put at top of the
-                                     ;; pel-bundle-autoloads.el: ensure that
-                                     ;; the directory name added to load-path
-                                     ;; does not have trailing "/", like other
-                                     ;; directories in loade-path because
-                                     ;; `add-to-list' compares strings exactly.
-                                     (concat "(add-to-list 'load-path"
-                                             "(directory-file-name"
-                                             " (file-name-directory"
-                                             "  (or load-file-name"
-                                             "      buffer-file-name))))\n")))
+                  (loaddefs-generate
+                   (list dir)
+                   output-file
+                   nil
+                   ;; code to put at top of the
+                   ;; pel-bundle-autoloads.el: ensure that
+                   ;; the directory name added to load-path
+                   ;; does not have trailing "/", like other
+                   ;; directories in load-path because
+                   ;; `add-to-list' compares strings
+                   ;; exactly and use the safe adder if it
+                   ;; exists.
+                   pel--auto-load-adder-code))
                 (setq generated-fname output-file)
                 (when (get-buffer "pel-bundle-autoloads.el")
                   (kill-buffer "pel-bundle-autoloads.el")))
@@ -839,6 +847,26 @@ and has extra code specified in EXTRA-CODE."
 
 \(require 'package)
 
+;; ----
+;; Utility function
+
+(defun pel--add-to-load-path-once (dir)
+  \"Add directory DIR to `load-path' if DIR is not already inside it.
+Prevent multiple insertion by literal string and by truename
+to avoid symlink/realpath double entries.\"
+  ;; load-path directories do not end with /
+  (let* ((norm (directory-file-name (expand-file-name dir)))
+         (norm-truename (ignore-errors (file-truename norm))))
+    (unless (seq-some
+             (lambda (p)
+               (let* ((p0 (directory-file-name (expand-file-name p)))
+                      (pt (ignore-errors (file-truename p0))))
+                 (or (string= p0 norm)
+                     (and norm-truename pt (string= pt norm-truename)))))
+             load-path)
+      (add-to-list 'load-path norm))))
+
+;; ----
 \(defvar pel-running-in-fast-startup-p nil)
 
 \(defvar pel-fast-startup-builtin-packages
@@ -1186,7 +1214,7 @@ Please report this internal code error to project maintainer!"
       (format "\
 ;; step 2: (only for Emacs >= 27)
   (when using-package-quickstart
-      (add-to-list 'load-path
+      (pel--add-to-load-path-once 'load-path
                    (format \"%s\"
                            (if force-graphics \"-graphics\" \"\"))))"
               safe-path))))

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-17 11:01:04 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-17 11:25:32 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -805,23 +805,20 @@ Return the complete file path name of the file written."
 (defvar pel-running-in-fast-startup-p) ; Really defined in init.el.
 ;;                                     ; here: prevent byte-compiler warnings.
 (defun pel-bundled-mode (activate)
-  "Activate PEL bundled mode if ACTIVATE is non-nil, de-activate it otherwise.
+  "Activate PEL bundled mode if ACTIVATE is non-nil, deactivate otherwise.
 
-This byte-compiles the pel_keys.el file with a new behaviour for the following
-macros that control PEL's management of external package installation and
-loading:
-- `pel-ensure-package-elpa'
+This byte-compiles the pel_keys.el file with the behaviour of macros
+like `pel-ensure-package-elpa' controlled by the value of ACTIVATE.
+When ACTIVATE is non-nil, the function `pel-in-fast-startup-p' returns t
+which prevents these macros from emitting code that checks for presence of
+external packages and loads them.
 
-When ACTIVATE is non-nil, then the function `pel-in-fast-startup-p' returns t
-which prevents these macros to emit code that check for presence of external
-package and to load them.
-
-Return a (activate . byte-compile result) cons cell."
-  (setq pel-running-in-fast-startup-p activate)
-  (cons pel-running-in-fast-startup-p
-        (byte-compile-file (concat (file-name-sans-extension
-                                    (locate-library "pel_keys"))
-                                   ".el"))))
+Return a (ACTIVATE . byte-compile result) cons cell."
+  (let ((pel-running-in-fast-startup-p activate))
+    (cons pel-running-in-fast-startup-p
+          (byte-compile-file (concat (file-name-sans-extension
+                                      (locate-library "pel_keys"))
+                                     ".el")))))
 
 (defun pel-setup-fast-startup-init (fname deps-pkg-versions-alist extra-code)
   "Write Emacs Lisp code to add the DEPS-PKG-VERSIONS-ALIST to Emacs in FNAME.

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-16 15:07:00 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-17 11:01:04 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -707,6 +707,13 @@ graphic mode."
 graphic mode."
   (pel--switch-to-elpa "elpa-reduced" for-graphics))
 
+;; Prevent warnings when compiling on Emacs < 29.
+;; where `loaddefs-generate' does not exist.
+(declare-function loaddefs-generate "loaddefs-gen"
+                  (dir output-file &optional excluded-files
+                       extra-data include-package-version
+                       generate-full))
+
 (defun pel-generate-autoload-file-for (dir)
   "Prepare (compile + autoload) all files in directory DIR.
 Return the complete name of the generated autoload file."
@@ -720,15 +727,21 @@ Return the complete name of the generated autoload file."
           (require 'loaddefs-gen)
           (condition-case-unless-debug err
               (progn
-                (when (fboundp 'loaddefs-generate) ; Prevent warnings when compiling on Emacs < 29.
-                  (with-no-warnings                ; where loaddefs-generate does not exist
-                    (loaddefs-generate (list dir)
-                                       output-file
-                                       nil
-                                       (concat "(add-to-list 'load-path"
-                                               " (file-name-directory"
-                                               " (or load-file-name"
-                                               "      buffer-file-name)))\n"))))
+                (when (fboundp 'loaddefs-generate)
+                  (loaddefs-generate (list dir)
+                                     output-file
+                                     nil
+                                     ;; code to put at top of the
+                                     ;; pel-bundle-autoloads.el: ensure that
+                                     ;; the directory name added to load-path
+                                     ;; does not have trailing "/", like other
+                                     ;; directories in loade-path because
+                                     ;; `add-to-list' compares strings exactly.
+                                     (concat "(add-to-list 'load-path"
+                                             "(directory-file-name"
+                                             " (file-name-directory"
+                                             "  (or load-file-name"
+                                             "      buffer-file-name))))\n")))
                 (setq generated-fname output-file)
                 (when (get-buffer "pel-bundle-autoloads.el")
                   (kill-buffer "pel-bundle-autoloads.el")))
@@ -1103,23 +1116,86 @@ If all is OK, it just returns nil."
 The Emacs directory (%s) is not compatible with PEL startup management."
         user-emacs-directory)))))
 
-(defun pel--create-pel-setup-fast-startup-init (deps-pkg-versions-alist new-bundle-dp)
-  "Write Emacs Lisp code to add the DEPS-PKG-VERSIONS-ALIST to Emacs with a bundle.
+
+(defun pel--setup-fast-startup-init-extra-code (bundle-dp)
+  "Return a string with Elisp code to add support for the PEL bundle package.
+The BUNDLE-DP is the directory path of the PEL bundle.
+
+The returned code string uses a `%s' placeholder at the `elpa-reduced'
+component of the path so that the generated `pel-fast-startup-init'
+function can select the plain or `-graphics' variant at startup time via
+its FORCE-GRAPHICS parameter.
+
+A warning is issued (via `display-warning') when:
+- BUNDLE-DP is nil or empty (cannot generate any path).
+- BUNDLE-DP does not contain \"elpa-reduced\" (the `%s' placeholder
+  substitution would be a no-op, silently disabling graphics-mode
+  load-path switching)."
+  ;;
+  ;; Guard 1: nil or empty path — nothing useful can be generated.
+  ;;          On error: skip step 2: return an empty string.
+  (if (or (null bundle-dp)
+          (string-empty-p bundle-dp))
+      (progn
+        (display-warning
+         'pel-setup
+         "pel--setup-fast-startup-init-extra-code: \
+bundle-dp is nil or empty; step 2 load-path code will be omitted.
+Please report this internal code error to project maintainer!"
+         :error)
+        ;; Return an empty string
+        "")
+    ;;
+    ;; Guard 2: path does not contain "elpa-reduced" — the %s substitution
+    ;; would be a no-op and graphics/terminal path selection would silently
+    ;; break.  However do not skip step 2 on this error.
+    (unless (string-match-p "elpa-reduced" bundle-dp)
+      (display-warning
+       'pel-setup
+       (format "pel--setup-fast-startup-init-extra-code: \
+bundle-dp \"%s\" does not contain \"elpa-reduced\".
+The generated step 2 load-path form will not distinguish between \
+graphics and terminal Emacs instances.
+Please report this internal code error to project maintainer!"
+               bundle-dp)
+       :error))
+    ;;
+    ;; Proceed: generate and return the string.
+    (let* (;; Introduce the %s placeholder at the elpa-reduced level so the
+           ;; generated code can pick plain or graphics variant at run time.
+           (bundle-with-placeholder
+            (replace-regexp-in-string
+             "elpa-reduced"
+             "elpa-reduced%s"
+             bundle-dp))
+           ;; Escape any remaining % that are NOT our intended %s placeholder
+           ;; to prevent misinterpretation by `format' when the user's path
+           ;; happens to contain a literal % character.
+           ;; We only want to protect % not followed by 's'.
+           (safe-path
+            (replace-regexp-in-string
+             "%\\([^s]\\)" "%%\\1"
+             bundle-with-placeholder)))
+      (format "\
+;; step 2: (only for Emacs >= 27)
+  (when using-package-quickstart
+      (add-to-list 'load-path
+                   (format \"%s\"
+                           (if force-graphics \"-graphics\" \"\"))))"
+              safe-path))))
+
+
+(defun pel--create-pel-setup-fast-startup-init (deps-pkg-versions-alist
+                                                new-bundle-dp)
+  "Write Elisp code to add the DEPS-PKG-VERSIONS-ALIST to Emacs with a bundle.
 
 NEW-BUNDLED-DP is the name of the new Elpa bundle directory."
   (pel-setup-fast-startup-init
    pel-fast-startup-init-fname
    deps-pkg-versions-alist
    (pel-string-when pel-emacs-27-or-later-p
-                    (format ";; step 2: (only for Emacs >= 27)
-  (when using-package-quickstart
-      (add-to-list 'load-path
-                   (format \"%s\"
-                           (if force-graphics \"-graphics\" \"\"))))"
-                            (replace-regexp-in-string
-                             "elpa-reduced"
-                             "elpa-reduced%s"
-                             new-bundle-dp)))))
+                    (pel--setup-fast-startup-init-extra-code
+                     new-bundle-dp))))
 
 ;; Declare native-compile-async to ensure the code compiles on older Emacs
 ;; where this function does not exists.  Code won't use it in those Emacs
@@ -1317,7 +1393,7 @@ Failed fast startup setup for %s after %d of %d steps: %s
  Please also report the problem as a bug in the PEL Github project."
                                 (pel-setup-mode-description for-graphics)
                                 step-count
-                                (if pel-emacs-27-or-later-p 19 17)
+                                (if pel-emacs-27-or-later-p 20 18)
                                 err
                                 user-emacs-directory))))
     (cd cd-original)))

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-15 11:26:32 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-16 15:07:00 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -406,7 +406,7 @@ slash) or in file name (without the terminating slash) format."
 Return nil if no problems found: all is OK, ready to use Emacs in
 independent environments for terminal and graphics mode."
   (require 'cus-edit)                   ; use: `custom-file'`
-  (let* ((used-elpa-dirpath (pel-elpa-dirpath 'at-startup))
+  (let* ((used-elpa-dirpath (pel-elpa-dirpath 'switch-dir))
          (custom-fname    (pel-elpa-name custom-file nil))
          (custom-fname-g  (pel-elpa-name custom-file :for-graphics))
          (elpa-dp         (pel-elpa-name used-elpa-dirpath nil))
@@ -501,7 +501,7 @@ Return a list of performed actions (in reverse order of execution)."
 
 Utility function.  If REASON-MSG is specified include that message on error."
   (require 'cus-edit)                   ; use: `custom-file'`
-  (let* ((used-elpa-dirpath (pel-elpa-dirpath 'at-startup))
+  (let* ((used-elpa-dirpath (pel-elpa-dirpath 'switch-dir))
          (custom-fn       (pel-elpa-name custom-file nil))
          (custom-fn-g     (pel-elpa-name custom-file :for-graphics))
          (elpa-dp         (pel-elpa-name used-elpa-dirpath nil))
@@ -688,7 +688,7 @@ There are inconsistencies in the PEL dual environment setup.
                 like \"elpa-complete\" or \"elpa-reduced\".
 - FOR-GRAPHICS: non-nil when dual environment is set and Emacs runs in
 graphic mode."
-  (let* ((used-elpa-dirpath (pel-elpa-dirpath 'at-startup))
+  (let* ((used-elpa-dirpath (pel-elpa-dirpath 'switch-dir))
          (adj (lambda (fn) (pel-elpa-name fn for-graphics))))
     (pel-point-symlink-to (λc adj used-elpa-dirpath)
                           (λc adj (pel-sibling-dirpath used-elpa-dirpath name)))))
@@ -1147,7 +1147,7 @@ GUI         Yes             t
 
 It must be non-nil when Emacs runs in GUI mode and PEL uses the dual-mode."
   (let* (;; define closures used to reduce visual clutter
-         (used-elpa-dirpath (pel-elpa-dirpath 'at-startup))
+         (used-elpa-dirpath (pel-elpa-dirpath 'switch-dir))
          (adj          (lambda (fn) (pel-elpa-name fn for-graphics))) ; adjust for graphics
          (elpa-sibling (lambda (dp) (pel-sibling-dirpath used-elpa-dirpath dp)))
          (step-count 0)
@@ -1389,7 +1389,7 @@ is only one or when its for the terminal (TTY) mode."
     (require 'pel-setup-27)
     (pel--setup-early-init pel-support-package-quickstart)
     (if pel-support-package-quickstart
-        (pel--create-package-quickstart (pel-elpa-dirpath 'at-startup) for-graphics)
+        (pel--create-package-quickstart (pel-elpa-dirpath 'final-dir-at-startup) for-graphics)
       (pel--remove-package-quickstart-files for-graphics))))
 
 ;;-pel-autoload

--- a/test/pel-fast-startup-init-test.el
+++ b/test/pel-fast-startup-init-test.el
@@ -1,0 +1,78 @@
+;;; pel-fast-startup-init-test.el --- Test generation of pel-fast-startup-init  -*- lexical-binding: t; -*-
+
+;; Created   : Sunday, May 17 2026.
+;; Author    : Pierre Rouleau <prouleau001@gmail.com>
+;; Time-stamp: <2026-05-17 21:50:39 EDT, updated by Pierre Rouleau>
+
+;; This file is part of the PEL package.
+;; This file is not part of GNU Emacs.
+
+;; Copyright (C) 2026  Pierre Rouleau
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; --------------------------------------------------------------------------
+;;; Commentary:
+;;
+;;
+
+;;; --------------------------------------------------------------------------
+;;; Dependencies:
+;;
+(require 'pel-setup)
+(require 'ert)
+
+;;; --------------------------------------------------------------------------
+;;; Code:
+;;
+
+(defun pel--test-byte-compile-file-clean (src)
+  "Byte-compile SRC and fail the test on any error or warning."
+  (let* ((byte-compile-warnings t)
+         (byte-compile-error-on-warn t)        ; Emacs ≥ 29 honors this
+         (log (get-buffer-create "*Compile-Log*"))
+         (start (with-current-buffer log (point-max))))
+    (should (byte-compile-file src))
+    ;; For Emacs < 29 (no error-on-warn), detect warnings in the new log tail.
+    (with-current-buffer log
+      (goto-char start)
+      (should-not (re-search-forward "\\<[Ww]arning\\>:" nil t)))))
+
+(ert-deftest ert-test-pel-fast-startup-init-compiles-clean ()
+  "Generate pel-fast-startup-init.el text and ensure byte-compilation is clean."
+  (let* ((deps '((dash (2 19 1)) (s (1 13 0))))
+         ;; Ensure \"elpa-reduced\" is present so %s substitution is active.
+         (bundle-dp (expand-file-name
+                     "X/elpa-reduced/pel-bundle-TEST"
+                     temporary-file-directory))
+         (extra (pel--setup-fast-startup-init-extra-code bundle-dp))
+         (text  (pel-setup-fast-startup-init-text deps extra))
+         (src   (make-temp-file "pel-fast-init" nil ".el"))
+         (elc   (concat (file-name-sans-extension src) ".elc")))
+    (unwind-protect
+        (progn
+          (with-temp-file src (insert text))
+          ;; Sanity: the quickstart guard should be present in the generated code.
+          (should (string-match-p "(when using-package-quickstart" text))
+          ;; Also ensure the once-only helper is referenced.
+          (should (string-match-p "(pel--add-to-load-path-once" text))
+          ;; Compile and enforce no warnings.
+          (pel--test-byte-compile-file-clean src))
+      (ignore-errors (delete-file src))
+      (ignore-errors (delete-file elc)))))
+
+;;; --------------------------------------------------------------------------
+(provide 'pel-fast-startup-init-test)
+
+;;; pel-fast-startup-init-test.el ends here

--- a/test/pel-package-test.el
+++ b/test/pel-package-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Wednesday, March 24 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-15 15:13:15 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-16 15:58:40 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -263,7 +263,17 @@
                    "/some/dir/for/elpa/packages/my-green-package-2036121110.100"
                    )))
     (should (equal (pel-pkgs-sorted-by-version pkglist)
-                   sorted))))
+                   sorted))
+
+    ;; Edge case: empty list
+    (should (equal (pel-pkgs-sorted-by-version '()) '()))
+    ;; Edge case: single element
+    (should (equal (pel-pkgs-sorted-by-version
+                    '("/some/dir/for/elpa/packages/my-green-package-2024121110.100"))
+                   '("/some/dir/for/elpa/packages/my-green-package-2024121110.100")))))
+
+
+
 
 ;;; --------------------------------------------------------------------------
 (provide 'pel-package-test)

--- a/test/pel-package-test.el
+++ b/test/pel-package-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Wednesday, March 24 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-03-22 12:49:08 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-15 15:13:15 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -243,6 +243,27 @@
              (pel-packages-for 'pel-use-markdown-mode)
              '((elpa . markdown-mode)
                (elpa . edit-indirect))))))
+
+(ert-deftest ert-test-pel-pkgs-sorted-by-version ()
+  "Test sorting the package numbers."
+  (let ((pkglist '(
+                   "/some/dir/for/elpa/packages/my-green-package-2026121110.100"
+                   "/some/dir/for/elpa/packages/my-green-package-2025091110.100"
+                   "/some/dir/for/elpa/packages/my-green-package-2023011110.100"
+                   "/some/dir/for/elpa/packages/my-green-package-2036121110.100"
+                   "/some/dir/for/elpa/packages/my-green-package-2024121110.100"
+                   "/some/dir/for/elpa/packages/my-green-package-2024021110.100"
+                   ))
+        (sorted  '(
+                   "/some/dir/for/elpa/packages/my-green-package-2023011110.100"
+                   "/some/dir/for/elpa/packages/my-green-package-2024021110.100"
+                   "/some/dir/for/elpa/packages/my-green-package-2024121110.100"
+                   "/some/dir/for/elpa/packages/my-green-package-2025091110.100"
+                   "/some/dir/for/elpa/packages/my-green-package-2026121110.100"
+                   "/some/dir/for/elpa/packages/my-green-package-2036121110.100"
+                   )))
+    (should (equal (pel-pkgs-sorted-by-version pkglist)
+                   sorted))))
 
 ;;; --------------------------------------------------------------------------
 (provide 'pel-package-test)

--- a/test/pel-text-transform-test.el
+++ b/test/pel-text-transform-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Sunday, April 19 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-03-22 19:32:09 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-18 10:41:31 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -131,15 +131,15 @@
     ("One two Three Four Five Six Seven Eight Nine Ten"
      (lambda ()
        (goto-char 4)
-       (pel-downcase-word-or-region))
+       (pel-downcase-word-or-region)))
     ("One two Three Four Five Six Seven Eight Nine Ten"
      (lambda ()
        (goto-char 8)
        (pel-downcase-word-or-region -1)))
-    ("One Two Three Four Five Six SeVen Eight Nine Ten"
+    ("One Two Three Four Five Six SEven Eight Nine Ten"
      (lambda ()
        (goto-char 30)
-       (pel-downcase-word-or-region))))))
+       (pel-downcase-word-or-region)))))
 
 (defconst pel--tt-test3
   '(;; initial string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded README benchmark with Apple Silicon startup timings, package counts, load-path details and session excerpts; NEWS updated to report quelpa-installable package counts.

* **New Features**
  * Dynamic handling of package directories so installs/restores and quickstart target the correct runtime (graphics vs terminal).
  * Package listing now supports version-aware sorting.

* **Bug Fixes**
  * Preserve editor state when editing package selections; improved package inventory and cleanup reporting.

* **Tests**
  * Added unit test for package-version sorting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->