### PR TITLE
Improvements to fast startup mode and documentation

### DIFF
--- a/doc/fast-startup-mode.rst
+++ b/doc/fast-startup-mode.rst
@@ -368,8 +368,8 @@ Customization Variables (selection)
     - ``byte-and-native-compile-it`` (byte-compile and native-compile;
       default).
 
-  - ``pel-compile-emacs-early-init``: same three-value choice as above for
-    ``early-init.el`` (where the file is early-init instead of init).
+  - ``pel-compile-emacs-early-init``: same three-value choice as above,
+    applied to ``early-init.el``.
 
 - Constant defined inside ``~/.emacs.d/init.el``.
   Edit that file to modify its value:

--- a/doc/fast-startup-mode.rst
+++ b/doc/fast-startup-mode.rst
@@ -360,6 +360,12 @@ Customization Variables (selection)
 
   - ``pel-support-package-quickstart`` (Emacs ≥ 27): enable/disable
     quickstart.
+  - ``pel-compile-emacs-init`` enable/disable byte compilation of your Emacs
+    init.el file.  The default is ``byte-and-native-compile-it`` to
+    byte-compile and native-compile the file.
+  - ``pel-compile-emacs-early-init`` enable/disable byte compilation of your Emacs
+    early-init.el file.  The default is ``byte-and-native-compile-it`` to
+    byte-compile and native compile the file.
 
 - Constant defined inside ``~/.emacs.d/init.el``.
   Edit that file to modify it's value:

--- a/doc/fast-startup-mode.rst
+++ b/doc/fast-startup-mode.rst
@@ -361,11 +361,15 @@ Customization Variables (selection)
   - ``pel-support-package-quickstart`` (Emacs ≥ 27): enable/disable
     quickstart.
   - ``pel-compile-emacs-init``: controls compilation of ``init.el`` after PEL
-    updates it.  Three values are supported: ``nil`` (do not compile; deletes any
-    existing ``.elc``), ``t`` (byte-compile only), or
-    ``byte-and-native-compile-it`` (byte-compile and native-compile; default).
-  - ``pel-compile-emacs-early-init``: same three-value choice for
-    ``early-init.el``.
+    updates it.  Three values are supported:
+
+    - ``nil`` (do not compile; deletes any existing ``.elc``),
+    - ``t`` (byte-compile only), or
+    - ``byte-and-native-compile-it`` (byte-compile and native-compile;
+      default).
+
+  - ``pel-compile-emacs-early-init``: same three-value choice as above for
+    ``early-init.el`` (where the file is early-init instead of init).
 
 - Constant defined inside ``~/.emacs.d/init.el``.
   Edit that file to modify it's value:

--- a/doc/fast-startup-mode.rst
+++ b/doc/fast-startup-mode.rst
@@ -372,7 +372,7 @@ Customization Variables (selection)
     ``early-init.el`` (where the file is early-init instead of init).
 
 - Constant defined inside ``~/.emacs.d/init.el``.
-  Edit that file to modify it's value:
+  Edit that file to modify its value:
 
   - ``pel-init-support-dual-environment-p``: separate terminal vs graphics
     custom files and package directories.

--- a/doc/fast-startup-mode.rst
+++ b/doc/fast-startup-mode.rst
@@ -1,11 +1,11 @@
-==============================
+=====================
 PEL Fast Startup Mode
-==============================
+=====================
 
 :URL: https://github.com/pierre-rouleau/pel/tree/master/doc
 :Project:  `PEL Project home page`_
-:Created:  2026-05-19
-:Modified: 2026-05-18 23:05:04 EDT, updated by Pierre Rouleau.
+:Created:  2026-05-18
+:Modified: 2026-05-19 23:05:04 EDT, updated by Pierre Rouleau.
 :License:
     Copyright (c) 2026 Pierre Rouleau <prouleau001@gmail.com>
 
@@ -360,12 +360,12 @@ Customization Variables (selection)
 
   - ``pel-support-package-quickstart`` (Emacs ≥ 27): enable/disable
     quickstart.
-  - ``pel-compile-emacs-init`` enable/disable byte compilation of your Emacs
-    init.el file.  The default is ``byte-and-native-compile-it`` to
-    byte-compile and native-compile the file.
-  - ``pel-compile-emacs-early-init`` enable/disable byte compilation of your Emacs
-    early-init.el file.  The default is ``byte-and-native-compile-it`` to
-    byte-compile and native compile the file.
+  - ``pel-compile-emacs-init``: controls compilation of ``init.el`` after PEL
+    updates it.  Three values are supported: ``nil`` (do not compile; deletes any
+    existing ``.elc``), ``t`` (byte-compile only), or
+    ``byte-and-native-compile-it`` (byte-compile and native-compile; default).
+  - ``pel-compile-emacs-early-init``: same three-value choice for
+    ``early-init.el``.
 
 - Constant defined inside ``~/.emacs.d/init.el``.
   Edit that file to modify it's value:

--- a/doc/fast-startup-mode.rst
+++ b/doc/fast-startup-mode.rst
@@ -356,12 +356,25 @@ Typical Workflow
 Customization Variables (selection)
 ===================================
 
-- ``pel-support-package-quickstart`` (Emacs ≥ 27): enable/disable quickstart.
-- ``pel-init-support-dual-environment-p``: separate terminal vs graphics
-  custom files and package directories.
+- User-option defined in ``pel--options.el`` that you can set via customization:
+
+  - ``pel-support-package-quickstart`` (Emacs ≥ 27): enable/disable
+    quickstart.
+
+- Constant defined inside ``~/.emacs.d/init.el``.
+  Edit that file to modify it's value:
+
+  - ``pel-init-support-dual-environment-p``: separate terminal vs graphics
+    custom files and package directories.
+
+- Constants defined inside the ``~/.emacs.d/early-init.el``
+  Edit that file to modify their values:
+
 - ``pel-early-init-support-gc-boost-p``: GC threshold boost during init.
 - ``pel-early-init-suppress-file-name-handler-p``: suppress file handlers.
 - ``pel-early-init-disable-ui-elements-p``: disable UI elements early.
+
+Activate them all to get the fastest Emacs startup.
 
 -----------------------------------------------------------------------------
 

--- a/doc/fast-startup-mode.rst
+++ b/doc/fast-startup-mode.rst
@@ -370,9 +370,9 @@ Customization Variables (selection)
 - Constants defined inside the ``~/.emacs.d/early-init.el``
   Edit that file to modify their values:
 
-- ``pel-early-init-support-gc-boost-p``: GC threshold boost during init.
-- ``pel-early-init-suppress-file-name-handler-p``: suppress file handlers.
-- ``pel-early-init-disable-ui-elements-p``: disable UI elements early.
+  - ``pel-early-init-support-gc-boost-p``: GC threshold boost during init.
+  - ``pel-early-init-suppress-file-name-handler-p``: suppress file handlers.
+  - ``pel-early-init-disable-ui-elements-p``: disable UI elements early.
 
 Activate them all to get the fastest Emacs startup.
 

--- a/example/init/init.el
+++ b/example/init/init.el
@@ -400,7 +400,7 @@ Also expands to the file true name, replacing symlinks by what they point to."
     ;; On Emacs >= 27 in fast-startup mode, package-activate-all has already
     ;; been called automatically by Emacs (after early-init, before init).
     ;; Calling package-initialize again via the hook would activate packages
-    ;; a second time, requesting duplicated load-path entries.
+    ;; a second time, producing duplicate load-path entries.
     ;; The hook is only needed for Emacs < 27, where there is no early-init.
     (when (< emacs-major-version 27)
       (with-no-warnings  ; prevent complaining about pel--init-package-support

--- a/example/init/init.el
+++ b/example/init/init.el
@@ -77,9 +77,12 @@
   "Directory where PEL Emacs Lisp source files are stored.")
 
 ;; --
-(defconst pel-init-file-version "0.3"
+(defconst pel-init-file-version "0.3.1"
   "Version of PEL init.el. Verified by pel-setup logic. Do NOT change.")
 ;; Update notes:
+;;  - version 0.3.1: In Emacs >= 27, code no longer setup the hook to execute
+;;                   `package-activate-all' after emacs startup because it has
+;;                   already been done by PEL early-init.
 ;;  - version 0.3: OPTION C code modified:
 ;;                 - Now explicitly load benchmark-init-modes.  It was not
 ;;                   required in older versions of Emacs but is required in
@@ -396,9 +399,14 @@ Also expands to the file true name, replacing symlinks by what they point to."
                                       pel-emacs-is-graphic-p))
         (message "WARNING: Failed loading pel-fast-startup-init\
  from user-emacs-directory")))
-    (with-no-warnings    ; prevent complaining about pel--init-package-support
-      (add-hook 'emacs-startup-hook (function pel--init-package-support))))
-
+    ;; On Emacs >= 27 in fast-startup mode, package-activate-all has already
+    ;; been called automatically by Emacs (after early-init, before init).
+    ;; Calling package-initialize again via the hook would activate packages
+    ;; a second time, requesting duplicated load-path entries.
+    ;; The hook is only needed for Emacs < 27, where there is no early-init.
+    (when (< emacs-major-version 27)
+      (with-no-warnings    ; prevent complaining about pel--init-package-support
+        (add-hook 'emacs-startup-hook (function pel--init-package-support)))))
 
   ;; -------------------------------------------------------------------------
   ;; Section 3: Delay loading of abbreviation definitions

--- a/example/init/init.el
+++ b/example/init/init.el
@@ -386,12 +386,10 @@ Also expands to the file true name, replacing symlinks by what they point to."
   ;;
   (defvar package-quickstart) ; declared only to prevent byte-compiler warning.
   (when pel-running-in-fast-startup-p
-    ;; Start fast startup for: - Emacs < 27
-    ;;                         - Emacs >= 27 when package quickstart is not used.
-    ;;                                       when used, early-init starts it.
-    (when (or (< emacs-major-version 27)
-              (null (boundp 'package-quickstart))
-              (not package-quickstart))
+    ;; Start fast startup for Emacs < 27.
+    ;; On Emacs >= 27 early-init.el always calls pel-fast-startup-init
+    ;; unconditionally (before package-activate-all fires).
+    (when (< emacs-major-version 27)
       (if (and (load (file-name-sans-extension pel-fast-startup-init-fname)
                      :noerror :nomessage)
                (fboundp 'pel-fast-startup-init))
@@ -405,7 +403,7 @@ Also expands to the file true name, replacing symlinks by what they point to."
     ;; a second time, requesting duplicated load-path entries.
     ;; The hook is only needed for Emacs < 27, where there is no early-init.
     (when (< emacs-major-version 27)
-      (with-no-warnings    ; prevent complaining about pel--init-package-support
+      (with-no-warnings  ; prevent complaining about pel--init-package-support
         (add-hook 'emacs-startup-hook (function pel--init-package-support)))))
 
   ;; -------------------------------------------------------------------------

--- a/pel--options.el
+++ b/pel--options.el
@@ -977,31 +977,66 @@ customization files."
   :safe #'booleanp)
 
 ;; ----
-(defcustom pel-compile-emacs-init nil
-  "Whether PEL setup commands that update init.el also `byte-compile' it.
+(defcustom pel-compile-emacs-init 'byte-and-native-compile-it
+  "Whether PEL setup commands that update init.el also compiles it.
+
+The default is to byte-compile and native-compile the init.el file to
+improve Emacs startup performance.
+
+If you want to test the validity of your init.el file, byte compile it
+from the command line with the el-byte-compile script available in PEL
+bin directory.
+
+If your init.el file is the PEL example/init/init.el template as it
+should with PEL, then you can byte-compile and native compile this
+file.
+
+Note: PEL does not use the use-package macro. But if you need to add
+your own code and want to use the use-package macro you will need to add
+`(eval-when-compile (require \\='use-package))` before the use of the
+macro inside your init.el to allow compilation.
 
 Note that this assumes that your init.el file does not prevent byte
-compilation.  If your file defines the `no-byte-compile' variable, remove that
-or force it nil if you want PEL to `byte-compile' it.
+compilation.  If your file defines the `no-byte-compile' variable,
+remove it or force it nil if you want PEL to `byte-compile' it.
 
-Unlike the pel-bundle and `package-quickstart' files, PEL will not change the
-value of `no-byte-compile' file variable in your init.el file."
+Unlike the pel-bundle and `package-quickstart' files, PEL will not
+change the value of `no-byte-compile' file variable in your init.el
+file."
   :group 'pel-fast-startup
-  :type 'boolean
-  :safe #'booleanp)
+  :type '(choice
+          (const :tag "do not compile it" nil)
+          (const :tag "byte-compile it" t)
+          (const :tag "byte-compile and native-compile it"
+                 byte-and-native-compile-it)))
 
-(defcustom pel-compile-emacs-early-init nil
-  "Whether PEL setup commands that update early-init.el also `byte-compile' it.
+(defcustom pel-compile-emacs-early-init 'byte-and-native-compile-it
+  "Whether PEL setup commands that update early-init.el also compiles it.
 
-Note that this assumes that your early-init.el file does not prevent byte
-compilation.  If your file defines the `no-byte-compile' variable, remove that
-or force it nil if you want PEL to `byte-compile' it.
+The default is to byte-compile and native-compile the early-init.el file
+to improve Emacs startup performance.
 
-Unlike the pel-bundle and `package-quickstart' files, PEL will not change the
-value of `no-byte-compile' file variable in your early-init.el file."
+If you want to test the validity of your early-init.el file, byte
+compile it from the command line with the el-byte-compile script
+available in PEL bin directory.
+
+If your early-init.el file is the PEL example/init/early-init.el
+template as it should with PEL, then you can byte-compile and native
+compile this file.
+
+Note that this assumes that your early-init.el file does not prevent
+byte compilation.  If your file defines the `no-byte-compile' variable,
+remove that or force it nil if you want PEL to `byte-compile' it.
+
+Unlike the pel-bundle and `package-quickstart' files, PEL will not
+change the value of `no-byte-compile' file variable in your
+early-init.el file."
   :group 'pel-fast-startup
-  :type 'boolean
-  :safe #'booleanp)
+  :type '(choice
+          (const :tag "do not compile it" nil)
+          (const :tag "byte-compile it" t)
+          (const :tag "byte-compile and native-compile it"
+                 byte-and-native-compile-it)))
 
 ;; ----
 (defcustom pel-support-package-quickstart nil

--- a/pel--options.el
+++ b/pel--options.el
@@ -978,7 +978,7 @@ customization files."
 
 ;; ----
 (defcustom pel-compile-emacs-init 'byte-and-native-compile-it
-  "Whether PEL setup commands that update init.el also compiles it.
+  "Whether PEL setup commands that update init.el also compile it.
 
 The default is to byte-compile and native-compile the init.el file to
 improve Emacs startup performance.
@@ -1011,7 +1011,7 @@ file."
                  byte-and-native-compile-it)))
 
 (defcustom pel-compile-emacs-early-init 'byte-and-native-compile-it
-  "Whether PEL setup commands that update early-init.el also compiles it.
+  "Whether PEL setup commands that update early-init.el also compile it.
 
 The default is to byte-compile and native-compile the early-init.el file
 to improve Emacs startup performance.

--- a/pel-setup-27.el
+++ b/pel-setup-27.el
@@ -2,12 +2,12 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-17 18:21:56 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-19 10:26:40 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
 
-;; Copyright (C) 2021, 2026  Pierre Rouleau
+;; Copyright (C) 2021-2026  Pierre Rouleau
 ;;
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -98,11 +98,13 @@
 (defun pel--set-dual-environment-in-emacs-early-init (use-dual-environment)
   "Update Emacs user early-init.el to USE-DUAL-ENVIRONMENT or not."
   (pel-create-early-init-if-missing)
-  (pel-update-emacs-user-init-file
-   "early-init.el"
-   (list
-    (list 'pel-early-init-support-dual-environment-p (not (null use-dual-environment))))
-   pel-compile-emacs-early-init))
+  (let* ((early-init-fname (locate-user-emacs-file "early-init.el"))
+         (elc-existed-p    (file-exists-p (concat early-init-fname "c"))))
+    (pel-update-emacs-user-init-file
+     "early-init.el"
+     (list
+      (list 'pel-early-init-support-dual-environment-p (not (null use-dual-environment))))
+     (or pel-compile-emacs-early-init elc-existed-p))))
 
 ;; ---------------------------------------------------------------------------
 
@@ -152,11 +154,13 @@ FOR-GRAPHICS is:
   "Update Emacs early-init.el file package quickstart setting.
 Set it according to the USE-PACKAGE-QUICKSTART argument."
   (pel-create-early-init-if-missing)
-  (pel-update-emacs-user-init-file
-   "early-init.el"
-   (list
-    (list 'pel-early-init-support-package-quickstart-p use-package-quickstart))
-   pel-compile-emacs-early-init))
+  (let* ((early-init-fname (locate-user-emacs-file "early-init.el"))
+         (elc-existed-p    (file-exists-p (concat early-init-fname "c"))))
+    (pel-update-emacs-user-init-file
+     "early-init.el"
+     (list
+      (list 'pel-early-init-support-package-quickstart-p use-package-quickstart))
+     (or pel-compile-emacs-early-init elc-existed-p))))
 
 (defun pel--setup-early-init (pkg-quickstart)
   "Create valid PEL early-init.el file and set its behaviour.
@@ -169,15 +173,17 @@ The behaviour is controlled by:
 - The value of `pel-shell-detection-envvar' user-option determines what
   environment variable absence is used to detect GUI launched Emacs."
   (pel-create-early-init-if-missing)
-  (pel-update-emacs-user-init-file
-   "early-init.el"
-   (list
-    (list 'pel-early-init-support-package-quickstart-p pkg-quickstart)
-    (list 'pel-early-init-support-dual-environment-p
-          pel-detected-dual-environment-in-init-p)
-    (list 'pel-early-init-shell-detection-envvar
-          pel-shell-detection-envvar))
-   pel-compile-emacs-early-init))
+  (let* ((early-init-fname (locate-user-emacs-file "early-init.el"))
+         (elc-existed-p    (file-exists-p (concat early-init-fname "c"))))
+    (pel-update-emacs-user-init-file
+     "early-init.el"
+     (list
+      (list 'pel-early-init-support-package-quickstart-p pkg-quickstart)
+      (list 'pel-early-init-support-dual-environment-p
+            pel-detected-dual-environment-in-init-p)
+      (list 'pel-early-init-shell-detection-envvar
+            pel-shell-detection-envvar))
+     (or pel-compile-emacs-early-init elc-existed-p))))
 
 (defun pel--store-with-package-quickstart (value)
   "Set `pel-support-package-quickstart' to new VALUE globally and persistently.

--- a/pel-setup-27.el
+++ b/pel-setup-27.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-19 10:26:40 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-19 16:40:37 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -54,6 +54,7 @@
 ;;                                    ;      `pel-remove-no-byte-compile-in'
 ;;                                    ;      `pel-update-emacs-user-init-file'
 ;;                                    ;      `pel-detected-dual-environment-in-init-p'
+;;                                    ;      `pel-create-early-init-if-missing'
 ;;; --------------------------------------------------------------------------
 ;;; Code:
 ;;

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-18 10:13:31 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-19 09:09:30 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -426,11 +426,26 @@ The early-init.el file is created inside the directory identified by the
 ;;* Update PEL constant values in init.el or early-init.el
 ;; =======================================================
 
+(defun pel--native-compile-if-available (el-fname)
+  "Native-compile EL-FNAME if native compilation is available on this Emacs."
+  (when (featurep 'native-compile)
+    (require 'comp-run)
+    (when (and (fboundp 'native-comp-available-p)
+               (native-comp-available-p))
+      ;; Use async compilation; the .eln will be ready for the next startup.
+      (native-compile-async (list el-fname) nil t))))
+
 (defun pel-compile-file-if (el-fname byte-compile-it)
   "Byte compile file EL-FNAME if BYTE-COMPILE-IT is set.
+
+It also native-compile it when native compilation is supported by Emacs
+and BYTE-COMPILE-IT is set to \\='byte-and-native-compile-it.
+
 Otherwise delete the .elc file if it exists."
   (if byte-compile-it
-      (byte-compile-file el-fname)
+      (when (and (byte-compile-file el-fname)
+                 (eq byte-compile-it 'byte-and-native-compile-it))
+        (pel--native-compile-if-available el-fname))
     ;; no compilation needed; remove any left-over .elc file
     (let ((elc-fname (concat el-fname "c")))
       (when (file-exists-p elc-fname)
@@ -448,7 +463,10 @@ Otherwise delete the .elc file if it exists."
     supported files.
 - SYMBOL-VALUES: a list of symbol-value pairs.  The symbol is the name of
   the variable to update to the specified value.
-- BYTE-COMPILE-IT: boolean.  If non-nil, byte compile resulting FNAME.
+- BYTE-COMPILE-IT: nil: does not compile file.
+                   non-nil, byte compile resulting FNAME.
+                   \\='byte-and-native-compile-it: byte compile and
+                   native compile if Emacs supports it.
 
 Raise a user error if the function does not find the file or the
 `defconst' form defining a specified symbol inside the file.  The error

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-19 10:46:59 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-19 16:58:59 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -508,11 +508,13 @@ non-nil, otherwise prevent it from using it.  Set
 `pel-init-support-dual-environment-p' to t when USE-DUAL-ENVIRONMENT is
 non-nil, to nil otherwise.  Byte compile the result file if the
 `pel-compile-emacs-init' user-option is turned on."
-  (pel-update-emacs-user-init-file
-   "init.el"
-   (list
-    (list 'pel-init-support-dual-environment-p (not (null use-dual-environment))))
-   pel-compile-emacs-init))
+  (let* ((init-fname (locate-user-emacs-file "init.el"))
+         (elc-existed-p (file-exists-p (concat init-fname "c"))))
+    (pel-update-emacs-user-init-file
+     "init.el"
+     (list
+      (list 'pel-init-support-dual-environment-p (not (null use-dual-environment))))
+     (or pel-compile-emacs-init elc-existed-p))))
 
 ;; ---------------------------------------------------------------------------
 ;;* Save user-option persistently

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-19 16:58:59 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-19 17:16:40 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -504,10 +504,16 @@ describes what was not found, requesting the user to fix it."
   "Update Emacs user init.el to USE-DUAL-ENVIRONMENT or not.
 
 Update init.el for dual environment when USE-DUAL-ENVIRONMENT is
-non-nil, otherwise prevent it from using it.  Set
-`pel-init-support-dual-environment-p' to t when USE-DUAL-ENVIRONMENT is
-non-nil, to nil otherwise.  Byte compile the result file if the
-`pel-compile-emacs-init' user-option is turned on."
+non-nil, otherwise prevent it from using it.
+
+Set `pel-init-support-dual-environment-p' to t when USE-DUAL-ENVIRONMENT
+is non-nil, to nil otherwise.
+
+Byte compile the result according to `pel-compile-emacs-init':
+- nil: do not compile; but recompile if init.elc already exists (to
+  keep it in sync with the updated source).
+- t: byte-compile only.
+- \\='byte-and-native-compile-it: byte-compile and native-compile."
   (let* ((init-fname (locate-user-emacs-file "init.el"))
          (elc-existed-p (file-exists-p (concat init-fname "c"))))
     (pel-update-emacs-user-init-file

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-19 10:27:02 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-19 10:46:59 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -110,7 +110,7 @@ In the current code this is only done by `pel--setup-dual-environment'")
 ;;* Emacs Initialisation file validation
 ;;  ====================================
 
-(defconst pel--expected-init-file-version "0.3"
+(defconst pel--expected-init-file-version "0.3.1"
   "Must match what is in the example/init/init.el.")
 
 (defconst pel--expected-early-init-file-version "0.3"

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-19 09:09:30 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-19 09:19:56 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -431,6 +431,7 @@ The early-init.el file is created inside the directory identified by the
   (when (featurep 'native-compile)
     (require 'comp-run)
     (when (and (fboundp 'native-comp-available-p)
+               (fboundp 'native-compile-async)
                (native-comp-available-p))
       ;; Use async compilation; the .eln will be ready for the next startup.
       (native-compile-async (list el-fname) nil t))))

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,12 +2,12 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-19 09:27:35 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-19 10:27:02 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
 
-;; Copyright (C) 2021, 2024, 2025, 2026  Pierre Rouleau
+;; Copyright (C) 2021-2026  Pierre Rouleau
 ;;
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -433,7 +433,8 @@ The early-init.el file is created inside the directory identified by the
                                                    selector))
 
 (defun pel--native-compile-if-available (el-fname)
-  "Native-compile EL-FNAME if native compilation is available on this Emacs."
+  "Native-compile EL-FNAME if native compilation is available on this Emacs.
+The resulting .eln file will be used on the next Emacs startup, not immediately."
   (when (featurep 'native-compile)
     (require 'comp-run)
     (when (and (fboundp 'native-comp-available-p)
@@ -445,10 +446,11 @@ The early-init.el file is created inside the directory identified by the
 (defun pel-compile-file-if (el-fname byte-compile-it)
   "Byte compile file EL-FNAME if BYTE-COMPILE-IT is set.
 
-It also native-compile it when native compilation is supported by Emacs
-and BYTE-COMPILE-IT is set to \\='byte-and-native-compile-it.
-
-Otherwise delete the .elc file if it exists."
+BYTE-COMPILE-IT controls the action:
+- nil: do not compile; delete the .elc file if it exists.
+- t: byte-compile EL-FNAME only.
+- \\='byte-and-native-compile-it: byte-compile and, when Emacs supports
+  native compilation, also native-compile EL-FNAME asynchronously."
   (if byte-compile-it
       (when (and (byte-compile-file el-fname)
                  (eq byte-compile-it 'byte-and-native-compile-it))
@@ -470,10 +472,12 @@ Otherwise delete the .elc file if it exists."
     supported files.
 - SYMBOL-VALUES: a list of symbol-value pairs.  The symbol is the name of
   the variable to update to the specified value.
-- BYTE-COMPILE-IT: nil: does not compile file.
-                   non-nil, byte compile resulting FNAME.
-                   \\='byte-and-native-compile-it: byte compile and
-                   native compile if Emacs supports it.
+- BYTE-COMPILE-IT controls the compilation action:
+  - nil: do not compile; delete the .elc file if it exists.
+  - t: byte-compile FNAME only.
+  - \\='byte-and-native-compile-it: byte-compile FNAME and, when Emacs
+    supports native compilation, also native-compile FNAME
+    asynchronously.
 
 Raise a user error if the function does not find the file or the
 `defconst' form defining a specified symbol inside the file.  The error

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-19 09:19:56 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-19 09:27:35 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -425,6 +425,12 @@ The early-init.el file is created inside the directory identified by the
 ;; ---------------------------------------------------------------------------
 ;;* Update PEL constant values in init.el or early-init.el
 ;; =======================================================
+
+;; Native compilation APIs are defined in comp-run (when available).
+(declare-function native-comp-available-p "comp-run")
+(declare-function native-compile-async "comp-run" (files
+                                                   &optional recursively load
+                                                   selector))
 
 (defun pel--native-compile-if-available (el-fname)
   "Native-compile EL-FNAME if native compilation is available on this Emacs."

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-19 17:24:44 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-19 17:39:04 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -1022,7 +1022,11 @@ list we ensure that Emacs package.el logic will not attempt to download
 these packages.  We don't need Emacs to download them because they have
 already been downloaded when Emacs was in normal startup mode.  The
 DEPS-PKG-VERSIONS-ALIST list was originally returned by the function
-`pel-elpa-disable-pkg-deps-in'."
+`pel-elpa-disable-pkg-deps-in'.
+
+After writing the file, unconditionally byte-compiles FNAME.  On Emacs 28+
+with native compilation support, also triggers asynchronous native
+compilation so the .eln is ready for the next Emacs startup."
   (with-temp-file fname
     (erase-buffer)
     (goto-char (point-min))
@@ -1281,7 +1285,7 @@ Please report this internal code error to project maintainer!"
                                                 new-bundle-dp)
   "Write Elisp code to add the DEPS-PKG-VERSIONS-ALIST to Emacs with a bundle.
 
-NEW-BUNDLED-DP is the name of the new Elpa bundle directory."
+NEW-BUNDLE-DP is the name of the new Elpa bundle directory."
   (pel-setup-fast-startup-init
    pel-fast-startup-init-fname
    deps-pkg-versions-alist

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-19 22:10:57 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-19 22:17:52 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -884,9 +884,9 @@ to properly point to elpa-reduced directory.\"
                  (string= (directory-file-name (file-truename expected-dir))
                           (directory-file-name link-target)))
       (display-warning
-        'pel-fast-startup-init
-        \"\
-WARNING: PEL fast-startup: the elpa symlink is missing or points to the wrong directory.
+       'pel-fast-startup-init
+       \"\
+!! PEL fast-startup: the elpa symlink is missing or points to the wrong directory.
          Please run M-x pel-setup-fast to restore fast-startup mode, or
                     M-x pel-setup-normal to revert to normal mode.
          Until then Emacs will start in a degraded state.\"

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-19 13:23:57 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-19 13:53:25 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -1012,7 +1012,15 @@ DEPS-PKG-VERSIONS-ALIST list was originally returned by the function
     (goto-char (point-min))
     (insert (pel-setup-fast-startup-init-text
              deps-pkg-versions-alist
-             extra-code))))
+             extra-code)))
+  ;; Byte-compile the generated file unconditionally.  No user-option guard
+  ;; is needed: pel-fast-startup-init.el is entirely managed by PEL, never
+  ;; edited by hand.  The .elc ensures fast loading on all supported Emacs
+  ;; versions.  On Emacs 28+ with native compilation support the .eln is
+  ;; built asynchronously and will be used from the next Emacs startup
+  ;; onward.
+  (when (byte-compile-file fname)
+    (pel--native-compile-if-available fname)))
 
 ;; --
 
@@ -1529,12 +1537,18 @@ is only one or when its for the terminal (TTY) mode."
   ;; but leave the elpa-reduced directory around in case some other
   ;; Emacs process is currently running in fast-start operation mode.
   (when (file-exists-p pel-fast-startup-init-fname)
-    (delete-file pel-fast-startup-init-fname))
+    (delete-file pel-fast-startup-init-fname)
+    ;; Also remove the byte-compiled version.
+    (let ((elc (concat pel-fast-startup-init-fname "c")))
+      (when (file-exists-p elc)
+        (delete-file elc))))
+  ;;
   (when pel-emacs-27-or-later-p
     (require 'pel-setup-27)
     (pel--setup-early-init pel-support-package-quickstart)
     (if pel-support-package-quickstart
-        (pel--create-package-quickstart (pel-elpa-dirpath 'final-dir-at-startup) for-graphics)
+        (pel--create-package-quickstart
+         (pel-elpa-dirpath 'final-dir-at-startup) for-graphics)
       (pel--remove-package-quickstart-files for-graphics))))
 
 ;;-pel-autoload

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,12 +2,12 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-18 22:26:52 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-19 10:27:23 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
 
-;; Copyright (C) 2021, 2022, 2023, 2024, 2025, 2026  Pierre Rouleau
+;; Copyright (C) 2021-2026  Pierre Rouleau
 ;;
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-19 17:01:32 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-19 17:14:39 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -953,7 +953,9 @@ Return the pkg/version alist.\"
 ;; together inside the elpa-reduced/pel-bundle *pseudo-package*.
 
 \(defun pel--pct (_packages)
-  \"Prevent package downloads during PEL fast-startup initialization.\"
+  \"Prevent package downloads during PEL fast-startup initialization.
+This temporary advice is removed once Emacs startup completes, restoring
+package download capabilities.\"
   nil)
 
 \(advice-add  'package-compute-transaction  :filter-return (function pel--pct))

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-19 15:24:07 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-19 16:02:54 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -951,6 +951,14 @@ Return the pkg/version alist.\"
   nil)
 
 \(advice-add  'package-compute-transaction  :filter-return (function pel--pct))
+
+;; Remove the startup-time download-suppression advice once Emacs has
+;; fully initialized, so that interactive package operations (including
+;; Emacs 29+ `package-vc-install') work correctly in the session.
+\(add-hook 'emacs-startup-hook
+          (lambda ()
+            (advice-remove 'package-compute-transaction
+                           (function pel--pct))))
 
 ;; ----
 ;; Ensure that `package-load-all-descriptors' uses the graphics-specific

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-19 17:14:39 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-19 17:24:44 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -879,13 +879,13 @@ to properly point to elpa-reduced directory.\"
   (let* ((elpa-link    (expand-file-name \"elpa\"         user-emacs-directory))
          (expected-dir (expand-file-name \"elpa-reduced\" user-emacs-directory))
          (link-target  (and (file-symlink-p elpa-link)
-                              (file-truename elpa-link))))
-      (unless (and link-target
-                   (string= (directory-file-name (file-truename expected-dir))
-                            (directory-file-name link-target)))
-        (display-warning
-         'pel-fast-startup-init
-         \"\
+                            (file-truename elpa-link))))
+    (unless (and link-target
+                 (string= (directory-file-name (file-truename expected-dir))
+                          (directory-file-name link-target)))
+      (display-warning
+        'pel-fast-startup-init
+        \"\
 ⚠️  PEL fast-startup: the elpa symlink is missing or points to the wrong directory.
        Please run M-x pel-setup-fast to restore fast-startup mode, or
                   M-x pel-setup-normal to revert to normal mode.
@@ -1272,9 +1272,8 @@ Please report this internal code error to project maintainer!"
       (format "\
 ;; step 2: (only for Emacs >= 27)
   (when using-package-quickstart
-      (pel--add-to-load-path-once
-                   (format \"%s\"
-                           (if force-graphics \"-graphics\" \"\"))))"
+    (pel--add-to-load-path-once
+      (format \"%s\" (if force-graphics \"-graphics\" \"\"))))"
               safe-path))))
 
 

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-19 10:27:23 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-19 13:23:57 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -829,7 +829,8 @@ Return a (ACTIVATE . byte-compile result) cons cell."
                                       (locate-library "pel_keys"))
                                      ".el")))))
 
-(defun pel-setup-fast-startup-init-text (deps-pkg-versions-alist extra-code)
+(defun pel-setup-fast-startup-init-text (deps-pkg-versions-alist
+                                         extra-code)
   "Return the Elisp code for the pel-fast-startup-init.el file.
 
 This file is required when PEL uses the fast startup mode.
@@ -849,7 +850,7 @@ and has extra code specified in EXTRA-CODE."
 \(require 'package)
 
 ;; ----
-;; Utility function
+;; Utility functions
 
 (defun pel--add-to-load-path-once (dir)
   \"Add directory DIR to `load-path' if DIR is not already inside it.
@@ -867,7 +868,23 @@ symlink/realpath double entries.\"
     (unless found
       (add-to-list 'load-path norm))))
 
-
+(defun pel--warn-if-invalid-elpa-symlink ()
+  \"Sanity check: warn if the elpa symlink does not point to elpa-reduced.\"
+  (let* ((elpa-link    (expand-file-name \"elpa\"         user-emacs-directory))
+         (expected-dir (expand-file-name \"elpa-reduced\" user-emacs-directory))
+         (link-target  (and (file-symlink-p elpa-link)
+                              (file-truename elpa-link))))
+      (unless (and link-target
+                   (string= (directory-file-name (file-truename expected-dir))
+                            (directory-file-name link-target)))
+        (display-warning
+         'pel-fast-startup-init
+         \"\
+⚠️  PEL fast-startup: the elpa symlink is missing or points to the wrong directory.
+       Please run M-x pel-setup-fast to restore fast-startup mode, or
+                  M-x pel-setup-normal to revert to normal mode.
+       Until then Emacs will start in a degraded state.\"
+         :error))))
 ;; ----
 \(defvar pel-running-in-fast-startup-p nil)
 
@@ -896,6 +913,12 @@ symlink/realpath double entries.\"
       or from early-init.el when package quickstart is not used.
 
 Return the pkg/version alist.\"
+  ;;
+  ;; Sanity check: verify that the elpa symlink points to elpa-reduced.
+  ;; If not, fast-startup cannot work correctly.  Warn user.
+  (pel--warn-if-invalid-elpa-symlink)
+  ;;
+  ;;
   (setq pel-force-graphic-specific-files force-graphics)
   ;;
   ;; Capture the original package-user-dir before it is transformed.

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-19 13:53:25 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-19 15:24:07 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -1537,11 +1537,11 @@ is only one or when its for the terminal (TTY) mode."
   ;; but leave the elpa-reduced directory around in case some other
   ;; Emacs process is currently running in fast-start operation mode.
   (when (file-exists-p pel-fast-startup-init-fname)
-    (delete-file pel-fast-startup-init-fname)
-    ;; Also remove the byte-compiled version.
-    (let ((elc (concat pel-fast-startup-init-fname "c")))
-      (when (file-exists-p elc)
-        (delete-file elc))))
+    (delete-file pel-fast-startup-init-fname))
+  ;; Also remove the byte-compiled version.
+  (let ((elc (concat pel-fast-startup-init-fname "c")))
+    (when (file-exists-p elc)
+      (delete-file elc)))
   ;;
   (when pel-emacs-27-or-later-p
     (require 'pel-setup-27)

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-19 17:39:04 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-19 22:10:57 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -886,11 +886,11 @@ to properly point to elpa-reduced directory.\"
       (display-warning
         'pel-fast-startup-init
         \"\
-⚠️  PEL fast-startup: the elpa symlink is missing or points to the wrong directory.
-       Please run M-x pel-setup-fast to restore fast-startup mode, or
-                  M-x pel-setup-normal to revert to normal mode.
-       Until then Emacs will start in a degraded state.\"
-         :error))))
+WARNING: PEL fast-startup: the elpa symlink is missing or points to the wrong directory.
+         Please run M-x pel-setup-fast to restore fast-startup mode, or
+                    M-x pel-setup-normal to revert to normal mode.
+         Until then Emacs will start in a degraded state.\"
+        :error))))
 ;; ----
 \(defvar pel-running-in-fast-startup-p nil)
 
@@ -955,7 +955,7 @@ Return the pkg/version alist.\"
 \(defun pel--pct (_packages)
   \"Prevent package downloads during PEL fast-startup initialization.
 This temporary advice is removed once Emacs startup completes, restoring
-package download capabilities.\"
+package download capabilities, including Emacs 29+ `package-vc-install'.\"
   nil)
 
 \(advice-add  'package-compute-transaction  :filter-return (function pel--pct))
@@ -1277,7 +1277,7 @@ Please report this internal code error to project maintainer!"
 ;; step 2: (only for Emacs >= 27)
   (when using-package-quickstart
     (pel--add-to-load-path-once
-      (format \"%s\" (if force-graphics \"-graphics\" \"\"))))"
+     (format \"%s\" (if force-graphics \"-graphics\" \"\"))))"
               safe-path))))
 
 

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-19 16:02:54 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-19 17:01:32 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -869,7 +869,13 @@ symlink/realpath double entries.\"
       (add-to-list 'load-path norm))))
 
 (defun pel--warn-if-invalid-elpa-symlink ()
-  \"Sanity check: warn if the elpa symlink does not point to elpa-reduced.\"
+  \"Sanity check: warn if the elpa symlink is absent or invalid.
+
+In PEL fast-startup mode `~/.emacs.d/elpa' must point to `elpa-reduced'.
+Issues a warning of category `pel-fast-startup-init' at :error level when
+the symlink is missing or points to the wrong directory, instructing the
+user to run `pel-setup-fast' or `pel-setup-normal' to rebuild the symlink
+to properly point to elpa-reduced directory.\"
   (let* ((elpa-link    (expand-file-name \"elpa\"         user-emacs-directory))
          (expected-dir (expand-file-name \"elpa-reduced\" user-emacs-directory))
          (link-target  (and (file-symlink-p elpa-link)
@@ -947,7 +953,7 @@ Return the pkg/version alist.\"
 ;; together inside the elpa-reduced/pel-bundle *pseudo-package*.
 
 \(defun pel--pct (_packages)
-  \"Filter packages to prevent downloads.\"
+  \"Prevent package downloads during PEL fast-startup initialization.\"
   nil)
 
 \(advice-add  'package-compute-transaction  :filter-return (function pel--pct))

--- a/pel_keys.el
+++ b/pel_keys.el
@@ -8113,13 +8113,30 @@ See `flyspell-auto-correct-previous-word' for more info."
 ;; -- dtrt-indent
 (when pel-use-dtrt-indent
   (pel-ensure-package-elpa dtrt-indent from: melpa)
-  (when (boundp 'dtrt-indent-global-mode)
-    (setq dtrt-indent-global-mode 'activated-by--pel-use-dtrt-indent))
-  (define-pel-global-prefix pel:indent-dtrt (kbd "<f11> TAB d"))
-  (define-key pel:indent-dtrt "d" 'dtrt-indent-try-set-offset)
-  (define-key pel:indent-dtrt "D" 'dtrt-indent-set)
-  (define-key pel:indent-dtrt "u" 'dtrt-indent-undo)
-  (define-key pel:indent-dtrt "?" 'dtrt-indent-diagnosis))
+
+  ;; CAUTION: do NOT customize `dtrt-indent-global-mode' user-option: to
+  ;; prevent adding a (dtrt-indent-global-mode ...) form into your
+  ;; emacs-customization.el file: that would force the dtrt-indent.el file to
+  ;; be loaded regardless of the setting!
+  ;; - Ref: my bug report: https://github.com/jscheid/dtrt-indent/issues/95
+  ;;
+  ;; Defer global-mode activation until the first file is actually opened.
+  ;; This avoids loading dtrt-indent during no-file startup.
+  ;; Once the hook fires it removes itself; the global mode then handles
+  ;; all subsequently created buffers automatically via after-change-major-mode-hook.
+  (defun pel--enable-dtrt-indent-global-mode ()
+    "Enable `dtrt-indent-global-mode' on first file visit, then self-remove."
+    (remove-hook 'find-file-hook #'pel--enable-dtrt-indent-global-mode)
+    (when (fboundp 'dtrt-indent-global-mode)
+      (dtrt-indent-global-mode 1)
+      (define-pel-global-prefix pel:indent-dtrt (kbd "<f11> TAB d"))
+      (define-key pel:indent-dtrt "d" 'dtrt-indent-try-set-offset)
+      (define-key pel:indent-dtrt "D" 'dtrt-indent-set)
+      (define-key pel:indent-dtrt "u" 'dtrt-indent-undo)
+      (define-key pel:indent-dtrt "?" 'dtrt-indent-diagnosis)))
+  (declare-function pel--enable-dtrt-indent-global-mode "pel_keys")
+  ;;
+  (add-hook 'find-file-hook #'pel--enable-dtrt-indent-global-mode))
 
 ;; -- indent-bars
 (when pel-use-indent-bars


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized customization vars into three categories and clarified how to enable all early-init optimizations for fastest startup.

* **New Features**
  * Compilation settings now offer three choices: disabled, byte-only, or byte+native; native compilation can run asynchronously when available.
  * Generated fast-startup init is always byte-compiled and may trigger native compilation; startup now warns if package layout looks invalid.

* **Behavior Changes**
  * Defers indent-mode activation until the first file visit to avoid running it during no-file startups.
  * Avoids duplicate package activation on newer Emacs versions by adjusting startup hook registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->