### PR TITLE
Add is-pel-in-fast-startup shell script

### DIFF
--- a/bin/is-pel-in-fast-startup
+++ b/bin/is-pel-in-fast-startup
@@ -4,20 +4,21 @@
 # Purpose   : Detect if PEL is in fast startup mode.
 # Created   : Wednesday, May 20 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-21 10:40:17 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 11:13:19 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
 #
-#
-
+# Shell command that detects whether Emacs operates in PEL Fast Startup mode.
 
 # ----------------------------------------------------------------------------
 # Dependencies
 # ------------
 #
-#
-
+# - basename  (POSIX)
+# - readlink  (POSIX)
+# - grep      (POSIX)
+# - printf    (POSIX)
 
 # ----------------------------------------------------------------------------
 # Code
@@ -36,10 +37,19 @@ print_usage()
   • Print this help information.
 
  Usage: %s [-q|--quiet]
-  • Check if whether Emacs is using PEL Fast Startup Mode.
-    Exit code is 0 if it is, 1 if Emacs operate in normal mode.
-  • By default the command prints 'yes' or 'no' unless the
-    -q or --quiet option is specified.
+  • Check whether Emacs is using PEL Fast Startup Mode.
+    Exit code is 0 if it is, 1 if Emacs operates in normal mode.
+  • By default the command prints a message like 'yes', 'no' or
+    'invalid PEL environment' unless the -q or --quiet option
+    is specified.
+
+ Exit code:
+   • 0 : all command arguments are OK, Emacs operates in PEL Fast Startup mode.
+   • 1 : all command arguments are OK, Emacs operates in normal mode.
+   • 2 : unexpected command arguments, including help request with something else.
+   • 3 : Emacs environment does not comply with PEL to allow activation of PEL
+         Fast Startup mode.
+
 " "${pgm_name}" "${pgm_name}" "${pgm_name}"
 }
 
@@ -48,10 +58,10 @@ print_usage()
 
 if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
     print_usage
-    if [ "$#" = "1" ]; then
+    if [ "$#" -eq 1 ]; then
         exit 0
     else
-        exit  1
+        exit 2
     fi
 fi
 
@@ -59,23 +69,47 @@ fi
 # Quiet request?
 if [ "$1" = "-q" ] || [ "$1" = "--quiet" ]; then
     quiet="yes"
+elif [ "$#" -gt 0 ]; then
+    printf -- "%s: Unknown option: %s\n" "${pgm_name}" "$1" >&2
+    printf -- "Use -h to print usage\n" >&2
+    exit 2
+fi
+
+# --
+# Determine effective Emacs user directory
+if [ -n "${EMACS_USER_DIRECTORY:-}" ]; then
+    emacs_dir="$EMACS_USER_DIRECTORY"
+elif [ -d "$HOME/.emacs.d" ]; then
+    emacs_dir="$HOME/.emacs.d"
+elif [ -n "${XDG_CONFIG_HOME:-}" ] && [ -d "${XDG_CONFIG_HOME}/emacs" ]; then
+    emacs_dir="${XDG_CONFIG_HOME}/emacs"
+elif [ -d "$HOME/.config/emacs" ]; then
+    emacs_dir="$HOME/.config/emacs"
+else
+    emacs_dir="$HOME/.emacs.d"
 fi
 
 # --
 # Check PEL mode
-in_fast_startup="no"
-if [ -L "$HOME/.emacs.d/elpa" ]; then
-    if readlink "$HOME/.emacs.d/elpa" | grep -q "elpa-reduced"; then
-        in_fast_startup="yes"
+output_message="no"
+exit_code=1
+if [ -L "$emacs_dir/elpa" ]; then
+    if [ -d "$emacs_dir/elpa-complete" ]; then
+        if readlink "$emacs_dir/elpa" | grep -q "elpa-reduced"; then
+            output_message="yes"
+            exit_code=0
+        fi
+    else
+        output_message="invalid PEL environment: missing elpa-complete directory"
+        exit_code=3
     fi
 fi
-if [ $quiet = "no" ]; then
-    echo $in_fast_startup
+if [ "$quiet" = "no" ]; then
+    echo "$output_message"
 fi
-if [ "$in_fast_startup" = "yes" ]; then
-    exit 0
-else
-    exit 1
-fi
+exit $exit_code
 
 # ----------------------------------------------------------------------------
+# Local Variables:
+# sh-shell: sh
+# End:

--- a/bin/is-pel-in-fast-startup
+++ b/bin/is-pel-in-fast-startup
@@ -4,7 +4,7 @@
 # Purpose   : Check and report whether Emacs is using PEL Fast Startup Mode.
 # Created   : Wednesday, May 20 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-21 12:49:19 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 13:52:45 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -99,7 +99,10 @@ elif [ -n "${XDG_CONFIG_HOME:-}" ] && [ -d "${XDG_CONFIG_HOME}/emacs" ]; then
 elif [ -d "$HOME/.config/emacs" ]; then
     emacs_dir="$HOME/.config/emacs"
 else
-    emacs_dir="$HOME/.emacs.d"
+    # No recognized Emacs user directory found; report and exit
+    printf -- "%s: no Emacs user directory found (tried ~/.emacs.d, XDG paths, ~/.config/emacs).\n" \
+        "${pgm_name}" >&2
+    exit 3
 fi
 
 # --
@@ -113,6 +116,9 @@ if [ -d "$emacs_dir/elpa" ]; then
             if readlink "$emacs_dir/elpa" | grep -q "elpa-reduced"; then
                 output_message="yes"
                 exit_code=0
+            else
+                # Symlink exists and is valid, but does not point to an elpa-reduced path
+                output_message="no"   # exit_code already 1
             fi
         else
             output_message="PEL environment missing elpa-complete directory; not yet set for fast startup"
@@ -131,12 +137,12 @@ else
     exit_code=3
 fi
 
-if [ "$quiet" = "no" ]; then
-    printf -- "%s\n" "$output_message"
-elif [ "$exit_code" -eq 3 ]; then
-    # Always report invalid environment, even in quiet mode
+if [ "$exit_code" -eq 3 ]; then
     printf -- "%s\n" "$output_message" >&2
+elif [ "$quiet" = "no" ]; then
+    printf -- "%s\n" "$output_message"
 fi
+
 exit "$exit_code"
 
 # ----------------------------------------------------------------------------

--- a/bin/is-pel-in-fast-startup
+++ b/bin/is-pel-in-fast-startup
@@ -4,7 +4,7 @@
 # Purpose   : Check and report whether Emacs is using PEL Fast Startup Mode.
 # Created   : Wednesday, May 20 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-21 12:09:12 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 12:49:19 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -19,7 +19,6 @@
 #
 # - readlink  (GNU coreutils / BSD; not strictly POSIX)
 # - grep      (POSIX)
-# - printf    (POSIX)
 
 # ----------------------------------------------------------------------------
 # Code
@@ -116,11 +115,11 @@ if [ -d "$emacs_dir/elpa" ]; then
                 exit_code=0
             fi
         else
-            output_message="invalid PEL environment: missing elpa-complete directory"
+            output_message="PEL environment missing elpa-complete directory; not yet set for fast startup"
             exit_code=3
         fi
     else
-        output_message="invalid PEL environment: $emacs_dir/elpa is a directory, not a symlink"
+        output_message="PEL environment: $emacs_dir/elpa is a directory, not a symlink; not yet set for fast startup"
         exit_code=3
     fi
 else

--- a/bin/is-pel-in-fast-startup
+++ b/bin/is-pel-in-fast-startup
@@ -1,0 +1,81 @@
+#!/bin/sh
+# SH FILE: is-pel-in-fast-startup
+#
+# Purpose   : Detect if PEL is in fast startup mode.
+# Created   : Wednesday, May 20 2026.
+# Author    : Pierre Rouleau <prouleau001@gmail.com>
+# Time-stamp: <2026-05-21 10:40:17 EDT, updated by Pierre Rouleau>
+# ----------------------------------------------------------------------------
+# Module Description
+# ------------------
+#
+#
+
+
+# ----------------------------------------------------------------------------
+# Dependencies
+# ------------
+#
+#
+
+
+# ----------------------------------------------------------------------------
+# Code
+# ----
+#
+#
+pgm_name="$(basename "$0")"
+quiet=no
+
+print_usage()
+{
+    printf -- "
+%s: Check and report whether Emacs is using PEL Fast Startup Mode.
+
+ Usage: %s h|--help
+  • Print this help information.
+
+ Usage: %s [-q|--quiet]
+  • Check if whether Emacs is using PEL Fast Startup Mode.
+    Exit code is 0 if it is, 1 if Emacs operate in normal mode.
+  • By default the command prints 'yes' or 'no' unless the
+    -q or --quiet option is specified.
+" "${pgm_name}" "${pgm_name}" "${pgm_name}"
+}
+
+# --
+# Check validity of arguments
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    print_usage
+    if [ "$#" = "1" ]; then
+        exit 0
+    else
+        exit  1
+    fi
+fi
+
+# --
+# Quiet request?
+if [ "$1" = "-q" ] || [ "$1" = "--quiet" ]; then
+    quiet="yes"
+fi
+
+# --
+# Check PEL mode
+in_fast_startup="no"
+if [ -L "$HOME/.emacs.d/elpa" ]; then
+    if readlink "$HOME/.emacs.d/elpa" | grep -q "elpa-reduced"; then
+        in_fast_startup="yes"
+    fi
+fi
+if [ $quiet = "no" ]; then
+    echo $in_fast_startup
+fi
+if [ "$in_fast_startup" = "yes" ]; then
+    exit 0
+else
+    exit 1
+fi
+
+# ----------------------------------------------------------------------------

--- a/bin/is-pel-in-fast-startup
+++ b/bin/is-pel-in-fast-startup
@@ -4,7 +4,7 @@
 # Purpose   : Check and report whether Emacs is using PEL Fast Startup Mode.
 # Created   : Wednesday, May 20 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-21 15:17:57 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 15:27:42 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -138,7 +138,7 @@ else
 fi
 
 case "$output_message" in
-    "yes" | "no")
+    yes | no )
     ;;
 
     * )

--- a/bin/is-pel-in-fast-startup
+++ b/bin/is-pel-in-fast-startup
@@ -1,21 +1,22 @@
 #!/bin/sh
 # SH FILE: is-pel-in-fast-startup
 #
-# Purpose   : Detect if PEL is in fast startup mode.
+# Purpose   : Check and report whether Emacs is using PEL Fast Startup Mode.
 # Created   : Wednesday, May 20 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-21 12:00:47 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 12:09:12 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
 #
 # Shell command that detects whether Emacs operates in PEL Fast Startup mode.
+# Also validates the Emacs user directory environment, checking if it matches
+# what is required by PEL.
 
 # ----------------------------------------------------------------------------
 # Dependencies
 # ------------
 #
-# - basename  (POSIX)
 # - readlink  (GNU coreutils / BSD; not strictly POSIX)
 # - grep      (POSIX)
 # - printf    (POSIX)
@@ -25,7 +26,7 @@
 # ----
 #
 #
-pgm_name="$(basename "$0")"
+pgm_name="${0##*/}"
 quiet=no
 
 print_usage()
@@ -84,8 +85,14 @@ fi
 # Determine effective Emacs user directory
 # Note: EMACS_USER_DIRECTORY is a PEL-specific environment variable that
 #       allows the user to override the Emacs user directory location explicitly.
-if [ -n "${EMACS_USER_DIRECTORY:-}" ] && [ -d "$EMACS_USER_DIRECTORY" ]; then
-    emacs_dir="$EMACS_USER_DIRECTORY"
+if [ -n "${EMACS_USER_DIRECTORY:-}" ]; then
+    if [ -d "$EMACS_USER_DIRECTORY" ]; then
+        emacs_dir="$EMACS_USER_DIRECTORY"
+    else
+        printf -- "%s: EMACS_USER_DIRECTORY is set to '%s' but that directory does not exist.\n" \
+            "${pgm_name}" "$EMACS_USER_DIRECTORY" >&2
+        exit 3
+    fi
 elif [ -d "$HOME/.emacs.d" ]; then
     emacs_dir="$HOME/.emacs.d"
 elif [ -n "${XDG_CONFIG_HOME:-}" ] && [ -d "${XDG_CONFIG_HOME}/emacs" ]; then

--- a/bin/is-pel-in-fast-startup
+++ b/bin/is-pel-in-fast-startup
@@ -4,7 +4,7 @@
 # Purpose   : Check and report whether Emacs is using PEL Fast Startup Mode.
 # Created   : Wednesday, May 20 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-21 13:52:45 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 15:17:57 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -26,7 +26,7 @@
 #
 #
 pgm_name="${0##*/}"
-quiet=no
+quiet="no"
 
 print_usage()
 {
@@ -136,6 +136,15 @@ else
     fi
     exit_code=3
 fi
+
+case "$output_message" in
+    "yes" | "no")
+    ;;
+
+    * )
+        output_message="${pgm_name}: ${output_message}"
+        ;;
+esac
 
 if [ "$exit_code" -eq 3 ]; then
     printf -- "%s\n" "$output_message" >&2

--- a/bin/is-pel-in-fast-startup
+++ b/bin/is-pel-in-fast-startup
@@ -4,7 +4,7 @@
 # Purpose   : Detect if PEL is in fast startup mode.
 # Created   : Wednesday, May 20 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-21 11:59:04 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 12:00:47 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -84,7 +84,7 @@ fi
 # Determine effective Emacs user directory
 # Note: EMACS_USER_DIRECTORY is a PEL-specific environment variable that
 #       allows the user to override the Emacs user directory location explicitly.
-if [ -n "${EMACS_USER_DIRECTORY:-}" ]; then
+if [ -n "${EMACS_USER_DIRECTORY:-}" ] && [ -d "$EMACS_USER_DIRECTORY" ]; then
     emacs_dir="$EMACS_USER_DIRECTORY"
 elif [ -d "$HOME/.emacs.d" ]; then
     emacs_dir="$HOME/.emacs.d"

--- a/bin/is-pel-in-fast-startup
+++ b/bin/is-pel-in-fast-startup
@@ -4,7 +4,7 @@
 # Purpose   : Detect if PEL is in fast startup mode.
 # Created   : Wednesday, May 20 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-21 11:45:19 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 11:59:04 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -82,6 +82,8 @@ fi
 
 # --
 # Determine effective Emacs user directory
+# Note: EMACS_USER_DIRECTORY is a PEL-specific environment variable that
+#       allows the user to override the Emacs user directory location explicitly.
 if [ -n "${EMACS_USER_DIRECTORY:-}" ]; then
     emacs_dir="$EMACS_USER_DIRECTORY"
 elif [ -d "$HOME/.emacs.d" ]; then
@@ -115,12 +117,16 @@ if [ -d "$emacs_dir/elpa" ]; then
         exit_code=3
     fi
 else
-    output_message="invalid PEL and Emacs environment: missing elpa directory"
+    if [ -L "$emacs_dir/elpa" ]; then
+        output_message="invalid PEL environment: $emacs_dir/elpa symlink target is not a directory"
+    else
+        output_message="invalid PEL and Emacs environment: missing elpa directory"
+    fi
     exit_code=3
 fi
 
 if [ "$quiet" = "no" ]; then
-    echo "$output_message"
+    printf -- "%s\n" "$output_message"
 elif [ "$exit_code" -eq 3 ]; then
     # Always report invalid environment, even in quiet mode
     printf -- "%s\n" "$output_message" >&2

--- a/bin/is-pel-in-fast-startup
+++ b/bin/is-pel-in-fast-startup
@@ -4,7 +4,7 @@
 # Purpose   : Detect if PEL is in fast startup mode.
 # Created   : Wednesday, May 20 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-21 11:13:19 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 11:23:45 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -33,7 +33,7 @@ print_usage()
     printf -- "
 %s: Check and report whether Emacs is using PEL Fast Startup Mode.
 
- Usage: %s h|--help
+ Usage: %s -h|--help
   • Print this help information.
 
  Usage: %s [-q|--quiet]
@@ -55,7 +55,6 @@ print_usage()
 
 # --
 # Check validity of arguments
-
 if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
     print_usage
     if [ "$#" -eq 1 ]; then
@@ -68,6 +67,11 @@ fi
 # --
 # Quiet request?
 if [ "$1" = "-q" ] || [ "$1" = "--quiet" ]; then
+    if [ "$#" -ne 1 ]; then
+        printf -- "%s: Unexpected arguments after %s\n" "${pgm_name}" "$1" >&2
+        printf -- "Use -h to print usage\n" >&2
+        exit 2
+    fi
     quiet="yes"
 elif [ "$#" -gt 0 ]; then
     printf -- "%s: Unknown option: %s\n" "${pgm_name}" "$1" >&2

--- a/bin/is-pel-in-fast-startup
+++ b/bin/is-pel-in-fast-startup
@@ -4,7 +4,7 @@
 # Purpose   : Detect if PEL is in fast startup mode.
 # Created   : Wednesday, May 20 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-21 11:31:25 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 11:45:19 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -16,7 +16,7 @@
 # ------------
 #
 # - basename  (POSIX)
-# - readlink  (POSIX)
+# - readlink  (GNU coreutils / BSD; not strictly POSIX)
 # - grep      (POSIX)
 # - printf    (POSIX)
 
@@ -39,9 +39,10 @@ print_usage()
  Usage: %s [-q|--quiet]
   • Check whether Emacs is using PEL Fast Startup Mode.
     Exit code is 0 if it is, 1 if Emacs operates in normal mode.
-  • By default the command prints a message like 'yes', 'no' or
-    'invalid PEL environment' unless the -q or --quiet option
-    is specified.
+  • By default the command prints a message like 'yes', 'no'
+    unless the -q or --quiet option is specified.
+  • If the PEL environment is invalid or incomplete, the command
+    always prints an error message on stderr.
 
  Exit code:
    • 0 : all command arguments are OK, Emacs operates in PEL Fast Startup mode.
@@ -100,7 +101,8 @@ exit_code=1
 if [ -d "$emacs_dir/elpa" ]; then
     if [ -L "$emacs_dir/elpa" ]; then
         if [ -d "$emacs_dir/elpa-complete" ]; then
-            if [ "$(basename "$(readlink "$emacs_dir/elpa")")" = "elpa-reduced" ]; then
+            # check for elpa-reduced (even ones with version suffix)
+            if readlink "$emacs_dir/elpa" | grep -q "elpa-reduced"; then
                 output_message="yes"
                 exit_code=0
             fi
@@ -116,10 +118,14 @@ else
     output_message="invalid PEL and Emacs environment: missing elpa directory"
     exit_code=3
 fi
+
 if [ "$quiet" = "no" ]; then
     echo "$output_message"
+elif [ "$exit_code" -eq 3 ]; then
+    # Always report invalid environment, even in quiet mode
+    printf -- "%s\n" "$output_message" >&2
 fi
-exit $exit_code
+exit "$exit_code"
 
 # ----------------------------------------------------------------------------
 # Local Variables:

--- a/bin/is-pel-in-fast-startup
+++ b/bin/is-pel-in-fast-startup
@@ -4,7 +4,7 @@
 # Purpose   : Detect if PEL is in fast startup mode.
 # Created   : Wednesday, May 20 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-21 11:23:45 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 11:31:25 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -97,16 +97,24 @@ fi
 # Check PEL mode
 output_message="no"
 exit_code=1
-if [ -L "$emacs_dir/elpa" ]; then
-    if [ -d "$emacs_dir/elpa-complete" ]; then
-        if readlink "$emacs_dir/elpa" | grep -q "elpa-reduced"; then
-            output_message="yes"
-            exit_code=0
+if [ -d "$emacs_dir/elpa" ]; then
+    if [ -L "$emacs_dir/elpa" ]; then
+        if [ -d "$emacs_dir/elpa-complete" ]; then
+            if [ "$(basename "$(readlink "$emacs_dir/elpa")")" = "elpa-reduced" ]; then
+                output_message="yes"
+                exit_code=0
+            fi
+        else
+            output_message="invalid PEL environment: missing elpa-complete directory"
+            exit_code=3
         fi
     else
-        output_message="invalid PEL environment: missing elpa-complete directory"
+        output_message="invalid PEL environment: $emacs_dir/elpa is a directory, not a symlink"
         exit_code=3
     fi
+else
+    output_message="invalid PEL and Emacs environment: missing elpa directory"
+    exit_code=3
 fi
 if [ "$quiet" = "no" ]; then
     echo "$output_message"

--- a/bin/setup/install-emacs-launcher-scripts.sh
+++ b/bin/setup/install-emacs-launcher-scripts.sh
@@ -4,7 +4,7 @@
 # Purpose   : Install important control scripts via symlinks in ~/bin.
 # Created   : Tuesday, May 28 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-21 15:10:26 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 15:20:42 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -93,12 +93,7 @@ printf -- "\nFor help on these commands use their --help command line option.\n"
 printf -- "\
    e --help is emacs --help.
    e opens an independent emacs process in terminal mode.
-   ge and ec have their own help, which are:\n\n"
-ge --help
-printf -- "\n\n"
-ec --help
-printf -- "\n\n"
-# No need to print the help of other scripts.
+   All other commands print their own help with -h or --help.\n\n"
 
 # ----------------------------------------------------------------------------
 #  Local Variables:

--- a/bin/setup/install-emacs-launcher-scripts.sh
+++ b/bin/setup/install-emacs-launcher-scripts.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
 # SH FILE: install-emacs-launcher-scripts.sh
 #
-# Purpose   : Install the e, ge and ce scripts in ~/bin.
+# Purpose   : Install the e, ge and ec scripts in ~/bin.
 # Created   : Tuesday, May 28 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-21 11:48:38 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 11:55:03 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
 #
-# Creates symbolic links from ~/bin to the e, ge and ce scripts.
+# Creates symbolic links from ~/bin to the e, ge and ec scripts.
 # Tell user to put ~/bin inside PATH if it's not already there.
 
 # ----------------------------------------------------------------------------
@@ -86,7 +86,7 @@ printf -- "\nFor help on these commands use their --help command line option.\n"
 printf -- "\
    e --help is emacs --help.
    e opens an independent emacs process in terminal mode.
-   eg and ec have their own help, which are:\n\n"
+   ge and ec have their own help, which are:\n\n"
 ge --help
 printf -- "\n\n"
 ec --help

--- a/bin/setup/install-emacs-launcher-scripts.sh
+++ b/bin/setup/install-emacs-launcher-scripts.sh
@@ -4,7 +4,7 @@
 # Purpose   : Install important control scripts via symlinks in ~/bin.
 # Created   : Tuesday, May 28 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-21 15:20:42 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 15:28:08 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -61,7 +61,7 @@ check_file "$HOME/bin/is-emacs-daemon-running"
 check_file "$HOME/bin/is-pel-in-fast-startup"
 
 # --
-# 2. Install the symlink:
+# 2. Install the symlinks:
 install_symlink_for()
 {
     ln -s "${bin_dirpath}/$1" "$HOME/bin/$1"  || exit 1

--- a/bin/setup/install-emacs-launcher-scripts.sh
+++ b/bin/setup/install-emacs-launcher-scripts.sh
@@ -4,12 +4,12 @@
 # Purpose   : Install important control scripts via symlinks in ~/bin.
 # Created   : Tuesday, May 28 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-21 12:51:04 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 12:56:47 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
 #
-# Creates symbolic links from ~/bin to several of the important PELscripts,
+# Creates symbolic links from ~/bin to several of the important PEL scripts,
 # such as e, ge, ec and several other scripts.
 #
 # Tell user to put ~/bin inside PATH if it's not already there.

--- a/bin/setup/install-emacs-launcher-scripts.sh
+++ b/bin/setup/install-emacs-launcher-scripts.sh
@@ -4,7 +4,7 @@
 # Purpose   : Install the e, ge and ce scripts in ~/bin.
 # Created   : Tuesday, May 28 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-02-18 18:10:20 EST, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 11:16:09 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -35,6 +35,8 @@ if [ ! -d "$HOME/bin" ]; then
     exit 1
 fi
 
+# --
+# 1. Pre-installation checks:
 check_file()
 {
     if [ -e "$1" ]; then
@@ -49,7 +51,10 @@ check_file "$HOME/bin/e"
 check_file "$HOME/bin/ge"
 check_file "$HOME/bin/ec"
 check_file "$HOME/bin/is-emacs-daemon-running"
+check_file "$HOME/bin/is-pel-in-fast-startup"
 
+# --
+# 2. Install the symlink:
 install_symlink_for()
 {
     ln -s "${bin_dirpath}/$1" "$HOME/bin/$1"  || exit 1
@@ -59,13 +64,17 @@ install_symlink_for e
 install_symlink_for ge
 install_symlink_for ec
 install_symlink_for is-emacs-daemon-running
+install_symlink_for is-pel-in-fast-startup
 
+# --
+# 3. Success listing:
 
 printf -- "SUCCESS!!\nInstallation of e, ge and ec scripts completed!\nThey are:\n\n"
 ls -l "$HOME/bin/e"
 ls -l "$HOME/bin/ge"
 ls -l "$HOME/bin/ec"
 ls -l "$HOME/bin/is-emacs-daemon-running"
+ls -l "$HOME/bin/is-pel-in-fast-startup"
 
 if [ "$(command -v e)" != "$HOME/bin/e" ]; then
     printf -- "***NEXT STEP:\n"

--- a/bin/setup/install-emacs-launcher-scripts.sh
+++ b/bin/setup/install-emacs-launcher-scripts.sh
@@ -4,7 +4,7 @@
 # Purpose   : Install important control scripts via symlinks in ~/bin.
 # Created   : Tuesday, May 28 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-21 15:04:51 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 15:10:26 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -18,7 +18,9 @@
 # Dependencies
 # ------------
 #
-# - dirname
+# - dirname   (POSIX)
+# - ln        (POSIX)
+# - ls        (POSIX)
 
 # ----------------------------------------------------------------------------
 # Code
@@ -102,5 +104,3 @@ printf -- "\n\n"
 #  Local Variables:
 #  sh-shell: sh
 #  End:
-
-#  LocalWords:  zsh

--- a/bin/setup/install-emacs-launcher-scripts.sh
+++ b/bin/setup/install-emacs-launcher-scripts.sh
@@ -4,15 +4,21 @@
 # Purpose   : Install important control scripts via symlinks in ~/bin.
 # Created   : Tuesday, May 28 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-21 12:56:47 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 13:55:14 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
 #
-# Creates symbolic links from ~/bin to several of the important PEL scripts,
-# such as e, ge, ec and several other scripts.
+# Creates symbolic links from ~/bin to important PEL scripts: e, ge, ec,
+# is-emacs-daemon-running and is-pel-in-fast-startup.
 #
 # Tell user to put ~/bin inside PATH if it's not already there.
+
+# ----------------------------------------------------------------------------
+# Dependencies
+# ------------
+#
+# - realpath  (GNU coreutils / BSD; not strictly POSIX)
 
 # ----------------------------------------------------------------------------
 # Code

--- a/bin/setup/install-emacs-launcher-scripts.sh
+++ b/bin/setup/install-emacs-launcher-scripts.sh
@@ -4,7 +4,7 @@
 # Purpose   : Install important control scripts via symlinks in ~/bin.
 # Created   : Tuesday, May 28 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-21 13:55:14 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 15:04:51 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -18,19 +18,16 @@
 # Dependencies
 # ------------
 #
-# - realpath  (GNU coreutils / BSD; not strictly POSIX)
+# - dirname
 
 # ----------------------------------------------------------------------------
 # Code
 # ----
 #
-# Extract name of executing script:
-#  - With Bash: script=${BASH_SOURCE[0]}
-#  - With zsh:  script=${(%):-%x}
+# Extract name of executing script using POSIX tools:
 #
-# Use POSIX compliant code here:
-script="$(realpath "$0")"
-script_dirpath="$(dirname "$script")"
+script_dirpath="$(cd "$(dirname "$0")" && pwd -P)"
+script="${script_dirpath}/${0##*/}"
 bin_dirpath="$(dirname "$script_dirpath")"
 
 # echo "The script is: ${script}"

--- a/bin/setup/install-emacs-launcher-scripts.sh
+++ b/bin/setup/install-emacs-launcher-scripts.sh
@@ -1,16 +1,17 @@
 #!/bin/sh
 # SH FILE: install-emacs-launcher-scripts.sh
 #
-# Purpose   : Install the e, ge and ec and other scripts in ~/bin.
+# Purpose   : Install important control scripts via symlinks in ~/bin.
 # Created   : Tuesday, May 28 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-21 12:11:40 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 12:51:04 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
 #
-# Creates symbolic links from ~/bin to the e, ge and ec scripts.
-# Also create symlinks for other utilities.
+# Creates symbolic links from ~/bin to several of the important PELscripts,
+# such as e, ge, ec and several other scripts.
+#
 # Tell user to put ~/bin inside PATH if it's not already there.
 
 # ----------------------------------------------------------------------------

--- a/bin/setup/install-emacs-launcher-scripts.sh
+++ b/bin/setup/install-emacs-launcher-scripts.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
-# SH FILE: install-scripts.sh
+# SH FILE: install-emacs-launcher-scripts.sh
 #
 # Purpose   : Install the e, ge and ce scripts in ~/bin.
 # Created   : Tuesday, May 28 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-21 11:16:09 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 11:48:38 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -69,7 +69,7 @@ install_symlink_for is-pel-in-fast-startup
 # --
 # 3. Success listing:
 
-printf -- "SUCCESS!!\nInstallation of e, ge and ec scripts completed!\nThey are:\n\n"
+printf -- "SUCCESS!!\nInstallation of all following scripts completed!\nThey are:\n\n"
 ls -l "$HOME/bin/e"
 ls -l "$HOME/bin/ge"
 ls -l "$HOME/bin/ec"
@@ -91,6 +91,7 @@ ge --help
 printf -- "\n\n"
 ec --help
 printf -- "\n\n"
+# No need to print the help of other scripts.
 
 # ----------------------------------------------------------------------------
 #  Local Variables:

--- a/bin/setup/install-emacs-launcher-scripts.sh
+++ b/bin/setup/install-emacs-launcher-scripts.sh
@@ -1,15 +1,16 @@
 #!/bin/sh
 # SH FILE: install-emacs-launcher-scripts.sh
 #
-# Purpose   : Install the e, ge and ec scripts in ~/bin.
+# Purpose   : Install the e, ge and ec and other scripts in ~/bin.
 # Created   : Tuesday, May 28 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-21 11:55:03 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-21 12:11:40 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
 #
 # Creates symbolic links from ~/bin to the e, ge and ec scripts.
+# Also create symlinks for other utilities.
 # Tell user to put ~/bin inside PATH if it's not already there.
 
 # ----------------------------------------------------------------------------
@@ -39,7 +40,7 @@ fi
 # 1. Pre-installation checks:
 check_file()
 {
-    if [ -e "$1" ]; then
+    if [ -e "$1" ] || [ -L "$1" ]; then
         printf -- "***ERROR: File %s already exists.\n" "$1"
         printf -- "   Was this already installed?\n"
         printf -- "   If not, remove that file or rename it and try again.\n\n"


### PR DESCRIPTION
* Use this script to check if Emacs operates in PEL fast startup mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a POSIX command-line checker that reports whether PEL is configured for fast startup; supports help and quiet modes and returns distinct exit codes for yes/no/invalid states.

* **Chores**
  * Updated the Emacs launcher installer to deploy the new checker and added a pre-installation guard to avoid install conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->