### PR TITLE
Improve message management in PEL mode management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-2026 by Pierre Rouleau
 
 # Author: Pierre Rouleau <prouleau001@gmail.com>
-# Last Modified Time-stamp: <2026-05-22 16:01:48 EDT, updated by Pierre Rouleau>
+# Last Modified Time-stamp: <2026-05-25 18:12:24 EDT, updated by Pierre Rouleau>
 # Keywords: packaging, build-control
 
 # This file is part of the PEL package
@@ -191,6 +191,7 @@ EL_FILES := pel--base.el \
 		pel--indent.el \
 		pel--keys-macros.el \
 		pel--macros.el \
+		pel--process.el \
 		pel--options.el \
 		pel-abbrev.el \
 		pel-ada.el \
@@ -796,6 +797,7 @@ pel--base.elc:            pel-comp.elc
 pel--install.elc:         pel--base.elc pel--indent.elc pel--options.elc pel--macros.elc
 pel--keys-macros.elc:     pel--base.elc pel--macros.elc pel--options.elc pel-prompt.elc pel-browse.elc
 pel--options.elc:         pel--base.elc
+pel--process.elc:         pel--options.elc
 pel-abbrev.elc:           pel--base.elc
 pel-ada.elc:              pel--base.elc pel--options.elc pel-indent.elc pel-modes.elc
 pel-align.elc:            pel-hash.elc pel--base.elc
@@ -918,7 +920,7 @@ pel-skels-rst.elc:        pel-prompt.elc pel-skels.elc pel-tempo.elc pel-text-in
 pel-skels.elc:            pel--base.elc pel--options.elc pel-prompt.elc
 pel-smartparens.elc:      pel--base.elc pel-syntax.elc
 pel-speedbar.elc:         pel--base.elc pel--macros.elc pel--options.elc
-pel-spell.elc:            pel--base.elc pel--macros.elc pel--options.elc pel-prompt.elc
+pel-spell.elc:            pel--base.elc pel--macros.elc pel--options.elc pel-prompt.elc pel--process.elc
 pel-syntax.elc:           pel--base.elc pel--options.elc pel--syntax-macros.elc pel--macros.elc
 pel-tcl.elc:              pel--base.elc pel--options.elc pel-ccp.elc pel-indent.elc pel-modes.elc
 pel-tempo.elc:            pel--keys-macros.elc pel-prompt.elc

--- a/NEWS
+++ b/NEWS
@@ -163,6 +163,10 @@ PEL -- Pragmatic Emacs Leverage --  NEWS         -*- org -*-
   - The *make stats* command now supports PEL fast startup mode ; it distinguishes between Emacs running in normal mode and fast startup mode
     and adjusts accordingly.
 - Fixes:
+  - Fix: detection of GUI Emacs launched from the OS, as opposed to being launched from a shell:
+    - Add the *pel-is-os-launched-gui-p* utility function in pel--base that does the detection.
+    - Use it inside pel_keys once allowing the addition of 'environment' variables specified by PEL customization in
+      the *pel-gui-process-environment* user-option.
   - Fix: key binding for Smalltalk that previously was hijacked by Swift's.
   - Regression fix: the ~<f12> <f3>~ key is available again in the C, C++ and Objective-C buffers.
   - Regression fix: when Bison support is requested via *pel-use-bison* support for C is required but the code

--- a/NEWS
+++ b/NEWS
@@ -164,14 +164,14 @@ PEL -- Pragmatic Emacs Leverage --  NEWS         -*- org -*-
     and adjusts accordingly.
 - Fixes:
   - Fix: detection of GUI Emacs launched from the OS, as opposed to being launched from a shell:
-    - Add the *pel-is-os-launched-gui-p* utility function in pel--base that does the detection.
+    - Add the *pel-is-os-launched-gui-p* utility function in pel--preocess that does the detection.
     - Use it inside pel_keys once allowing the addition of 'environment' variables specified by PEL customization in
       the *pel-gui-process-environment* user-option.
     - The *pel-shell-detection-envvar* user-option is no longer used and was removed.
       The *pel-emacs-gui-programs* user-option is used instead.  By default it is unset and pel-is-os-launched-gui-p
       uses heuristics to identify whether the current Emacs is a pure GUI process; this is 95% reliable.  To increase
       the reliability and speed up pel-is-os-launched-gui-p, identify the absolute path of each pure GUI Emacs program
-      used in your system inside the pel-emacs-gui-program-dp user-option.
+      used in your system inside the pel-emacs-gui-programs user-option.
   - Fix: key binding for Smalltalk that previously was hijacked by Swift's.
   - Regression fix: the ~<f12> <f3>~ key is available again in the C, C++ and Objective-C buffers.
   - Regression fix: when Bison support is requested via *pel-use-bison* support for C is required but the code

--- a/NEWS
+++ b/NEWS
@@ -167,6 +167,11 @@ PEL -- Pragmatic Emacs Leverage --  NEWS         -*- org -*-
     - Add the *pel-is-os-launched-gui-p* utility function in pel--base that does the detection.
     - Use it inside pel_keys once allowing the addition of 'environment' variables specified by PEL customization in
       the *pel-gui-process-environment* user-option.
+    - The *pel-shell-detection-envvar* user-option is no longer used and was removed.
+      The *pel-emacs-gui-programs* user-option is used instead.  By default it is unset and pel-is-os-launched-gui-p
+      uses heuristics to identify whether the current Emacs is a pure GUI process; this is 95% reliable.  To increase
+      the reliability and speed up pel-is-os-launched-gui-p, identify the absolute path of each pure GUI Emacs program
+      used in your system inside the pel-emacs-gui-program-dp user-option.
   - Fix: key binding for Smalltalk that previously was hijacked by Swift's.
   - Regression fix: the ~<f12> <f3>~ key is available again in the C, C++ and Objective-C buffers.
   - Regression fix: when Bison support is requested via *pel-use-bison* support for C is required but the code

--- a/doc/pel-manual.rst
+++ b/doc/pel-manual.rst
@@ -4,7 +4,7 @@ PEL -- Pragmatic Emacs Leverage
 
 :URL: https://github.com/pierre-rouleau/pel/blob/master/doc/pel-manual.rst
 :Project:  `PEL Project home page`_
-:Modified: 2026-05-25 17:53:44 EDT, updated by Pierre Rouleau.
+:Modified: 2026-05-25 18:59:20 EDT, updated by Pierre Rouleau.
 :License:
     Copyright (c) 2020-2026 Pierre Rouleau <prouleau001@gmail.com>
 
@@ -1136,14 +1136,16 @@ Emacs processes:
 - PEL provides the `ec`_ command to launch GUI Emacs from the shell.
   This shell script sets the ``PEL_EMACS_IN_GRAPHICS`` environment variable to
   the value "1".  PEL internal logic checks for this value.
-- PEL provides the ``pel-emacs-gui-programs`` user-option to identify
+- PEL provides ``pel-is-os-launched-gui-p`` function that returns t when the
+  current Emacs is a OS launched GUI program.
+  It uses the ``pel-emacs-gui-programs`` user-option to identify
   the absolute path of one or several GUI Emacs programs that can be launched
   from the OS GUI (the desktop or whatever the OS supports).
 
-  - By default this is unset and PEL logic uses heuristics in attempt to
-    identify the GUI Emacs.  It's not 100% reliable so it's best to customize
-    the ``pel-emacs-gui-programs`` user-option and identify the GUI Emacs
-    programs you use.
+  - By default this is unset and ``pel-is-os-launched-gui-p`` logic uses
+    heuristics in attempt to identify the GUI Emacs.  It's not 100% reliable
+    so it's best to customize the ``pel-emacs-gui-programs`` user-option and
+    identify the GUI Emacs programs you use.
   - Doing it will also allows detection GUI program inside early-init.el and
     will allow PEL to inject or replace environment variables top values you
     identify inside the ``pel-gui-process-environment`` user-option.  That

--- a/doc/pel-manual.rst
+++ b/doc/pel-manual.rst
@@ -4,7 +4,7 @@ PEL -- Pragmatic Emacs Leverage
 
 :URL: https://github.com/pierre-rouleau/pel/blob/master/doc/pel-manual.rst
 :Project:  `PEL Project home page`_
-:Modified: 2026-05-21 15:54:10 EDT, updated by Pierre Rouleau.
+:Modified: 2026-05-25 17:53:44 EDT, updated by Pierre Rouleau.
 :License:
     Copyright (c) 2020-2026 Pierre Rouleau <prouleau001@gmail.com>
 
@@ -1130,32 +1130,28 @@ variables are read by PEL's code but also by the code in the ``early-init.el``
 Although this method requires an initial manual setup it runs quickly and does
 not slow Emacs startup [#purcell]_.
 
-PEL's method requires 2 environment variables and logic inside both
-early-init.el and inside init.el.
+PEL uses a different method that supports two different ways of launching GUI
+Emacs processes:
 
-The environment variables are used like this:
+- PEL provides the `ec`_ command to launch GUI Emacs from the shell.
+  This shell script sets the ``PEL_EMACS_IN_GRAPHICS`` environment variable to
+  the value "1".  PEL internal logic checks for this value.
+- PEL provides the ``pel-emacs-gui-programs`` user-option to identify
+  the absolute path of one or several GUI Emacs programs that can be launched
+  from the OS GUI (the desktop or whatever the OS supports).
 
-========== ========== ==============================================
-Variable 1 Variable 2 Detected mode
-========== ========== ==============================================
-Not set    N/A        GUI launched Emacs running in graphics mode.
-Not set    Set to "1" Shell launched Emacs running in graphics mode.
-Set        Not set    Shell launched Emacs running in terminal mode.
-========== ========== ==============================================
+  - By default this is unset and PEL logic uses heuristics in attempt to
+    identify the GUI Emacs.  It's not 100% reliable so it's best to customize
+    the ``pel-emacs-gui-programs`` user-option and identify the GUI Emacs
+    programs you use.
+  - Doing it will also allows detection GUI program inside early-init.el and
+    will allow PEL to inject or replace environment variables top values you
+    identify inside the ``pel-gui-process-environment`` user-option.  That
+    gives you even more control to what your GUI Emacs sees in the environment.
 
-- **Variable 1**: identified by the ``pel-shell-detection-envvar`` user
-  option.
-
-  - The default value of the user-option is the specially reserved "_"
-    environment variable used by Bash. If you do not use Bash to launch Emacs
-    you will have to use something else.  In the worst case, use ``PEL_SHELL``
-    and set that environment variable inside your shell startup script
-    (something like ``~/.bash_profile``).
-
-- **Variable 2**: ``PEL_EMACS_IN_GRAPHICS`` environment variable.
-  This variable must be set to ``"1"`` by the shell script that launches the
-  shell launched Emacs in graphics mode.  See the script examples in the
-  sub-sections of `Launching graphics mode Emacs from a shell`_.
+For more instruction on launching Emacs with PEL see
+the script examples in the
+sub-sections of `Launching graphics mode Emacs from a shell`_.
 
 
 If you plan to use PEL support for package quickstart, you must use an
@@ -1191,10 +1187,10 @@ section PEL provides a solution to this problem, a solution that does not slow
 down Emacs startup and requires you to set one or two PEL customization
 user-option variables:
 
-- ``pel-shell-detection-envvar`` to identify an environment variable whose
-  presence identifies that Emacs was launched by a shell and absence
-  identifies that Emacs was launched from a GUI application such as Windows
-  Explorer, macOS Finder or something like that.
+- ``pel-emacs-gui-programs`` to identify the absolute path of all pure GUI
+  Emacs programs you use in your system;  the Emacs programs
+  launched from a GUI application such as Windows
+  Explorer, macOS Finder or the equivalent.
 
 - ``pel-gui-process-environment`` is where you define the environment
   variables for the GUI Emacs.  You can define any environment variable name
@@ -1219,11 +1215,6 @@ checker program (aspell, hunspell or ispell) or several compilers.
   `example/init/init.el`_ file:
 
   - Set OPTION A: set ``pel-init-support-dual-environment-p`` to ``t``
-  - Set OPTION B: set ``pel-ei-shell-detection-envvar`` to the name of the
-    environment variable your shell always set or the one you always set
-    inside your shell startup script (something like ``PEL_SHELL``).
-    Its value should be the same as what is defined by the
-    ``pel-shell-detection-envvar`` user-option.
 
 - For Emacs 27 and later, to support the package quickstart feature you must
   also create an ``early-init.el`` file that has the logic shown inside the
@@ -1241,7 +1232,7 @@ like Windows Explorer or macOS Finder you must also do the following:
 - Type the ``<f11> M-s <f2>`` key sequence to open the customization buffer
   where you can set these two user-option variables.
 
-  - Set the values of ``pel-shell-detection-envvar`` and ``environment``.
+  - Set the values of ``pel-emacs-gui-programs`` and ``pel-gui-process-environment``.
     Save the customization file.
 
 - Restart Emacs for these to take effect.

--- a/example/init/early-init.el
+++ b/example/init/early-init.el
@@ -20,10 +20,9 @@
 ;; the code must resort to environment variables to detect if Emacs is
 ;; running in graphics mode or in terminal/TTY mode.  The code uses the
 ;; presence of the "PEL_EMACS_IN_GRAPHICS" environment variable set to "1 to
-;; identify the graphics mode when Emacs is launched from a shell and the
-;; absence of an environment variable identified by the
-;; `pel-early-init-shell-detection-envvar' when Emacs is launched from a GUI
-;; application launcher.
+;; identify the graphics mode when Emacs is launched from a shell. For pure
+;; GUI Emacs PEL uses the `pel-emacs-gui-programs'; the absolute path of all
+;; GUI Emacs commands available on this system.
 ;;
 ;; The code of this file does not load any Emacs Lisp file, it only uses what
 ;; is already available: the Emacs Lisp forms implemented in C and the ones
@@ -64,9 +63,7 @@
 ;;     used.  If your shell does not have such environment variable, use
 ;;     something like "PEL_SHELL" and define it inside your shell
 ;;     initialization file (something like ~/.bashrc or ~/.bash_profile).
-;;     - Identified in early-init.el by `pel-early-init-shell-detection-envvar',
-;;       and set by PEL command to the same value as the
-;;       `pel-shell-detection-envvar' user-option.
+;;     - Identified in early-init.el by `pel-emacs-gui-programs'.
 ;;
 ;; - PEL fast startup:
 ;;   Whether PEL activates the fast startup mode.
@@ -125,10 +122,8 @@ If you want to use some other file, please modify the initialized value.")
 (defconst pel-early-init-support-dual-environment-p nil
   "When t PEL uses 2 custom files: one for TTY and one for graphic mode.")
 
-(defconst pel-early-init-shell-detection-envvar "_"
-  "Name of envvar used to detect that Emacs was launched by a shell.
-The value should be the same as `pel-shell-detection-envvar' user-variable
-defined in pel--options.el")
+(defconst pel-early-init-emacs-gui-programs nil
+  "List of absolute paths of Emacs executables known to be pure GUI programs.`")
 
 (defconst pel-early-init-support-gc-boost-p nil
   "When t, raise GC threshold during startup and restore it afterwards.")
@@ -144,20 +139,25 @@ Has no effect when Emacs runs in terminal/TTY mode.")
 ;; The code below this line does not require editing.
 ;; ==================================================
 
-(defconst pel-early-init-file-version "0.3"
+(defconst pel-early-init-file-version "0.4"
   "Version of PEL early-init.el. Verified by pel-setup logic. Do NOT change.")
+
+(defconst pel--ei-in-graphics-p
+  (or
+   ;; For PEL controlled ec launched GUI where PEL_EMACS_IN_GRAPHICS envvar is defined.
+   (string-equal (getenv "PEL_EMACS_IN_GRAPHICS") "1")
+   ;; For pure GUI programs identified in `pel-emacs-gui-programs' user-option
+   ;; then copied into `pel-early-init-emacs-gui-programs' above.
+   (and pel-early-init-emacs-gui-programs
+        (member (expand-file-name invocation-name invocation-directory)
+                pel-early-init-emacs-gui-programs)))
+  "Non-nil when early-init.el detects that Emacs is running in graphics mode.
+Uses the same heuristic as `pel-force-graphic-specific-custom-file-p'.")
 
 (defconst pel-force-graphic-specific-custom-file-p
   (and pel-early-init-support-dual-environment-p
-       (or (string-equal (getenv "PEL_EMACS_IN_GRAPHICS") "1")
-           (not (getenv pel-early-init-shell-detection-envvar))))
+       pel--ei-in-graphics-p)
   "Force independent graphics mode customization.")
-
-(defconst pel--ei-in-graphics-p
-  (or (string-equal (getenv "PEL_EMACS_IN_GRAPHICS") "1")
-      (not (getenv pel-early-init-shell-detection-envvar)))
-  "Non-nil when early-init.el detects that Emacs is running in graphics mode.
-Uses the same heuristic as `pel-force-graphic-specific-custom-file-p'.")
 
 ;; ---------------------------------------------------------------------------
 ;; GC Threshold Boost During Startup

--- a/example/init/early-init.el
+++ b/example/init/early-init.el
@@ -111,7 +111,7 @@ If you want to use some other file, please modify the initialized value.")
 ;; PEL Controlled values
 ;; ---------------------
 ;;
-;; The following 3 defconst forms are controlled by the function
+;; The following 6 defconst forms are controlled by the function
 ;; `pel--update-early-init' used by PEL commands code. Therefore you do not
 ;; need to edit this file manually. The value MUST remain at the end of the
 ;; line for each of these forms.  The docstring MUST start on the next line.
@@ -123,7 +123,7 @@ If you want to use some other file, please modify the initialized value.")
   "When t PEL uses 2 custom files: one for TTY and one for graphic mode.")
 
 (defconst pel-early-init-emacs-gui-programs nil
-  "List of absolute paths of Emacs executables known to be pure GUI programs.`")
+  "List of absolute paths of Emacs executables known to be pure GUI programs.")
 
 (defconst pel-early-init-support-gc-boost-p nil
   "When t, raise GC threshold during startup and restore it afterwards.")

--- a/pel--base.el
+++ b/pel--base.el
@@ -36,6 +36,7 @@
 ;; Emacs TTY/Graphics Mode Detection
 ;; - `pel-emacs-is-a-tty-p'
 ;; - `pel-can-display-special-chars-p'
+;; - `pel-is-os-launched-gui-p'
 ;;
 ;; Assignment operator macros
 ;;  - `pel+='
@@ -468,6 +469,21 @@ Other uses risk returning non-nil value that point to the wrong file."
   "Predicate: t if Emacs can properly show Unicode characters like 👍 or 👎."
   (and (eq system-type 'darwin)
        (not (display-graphic-p))))
+
+(defun pel-is-os-launched-gui-p ()
+  "Predicate: t when Emacs is a GUI Emacs launched from the OS, not a shell."
+  (cond
+   ((eq system-type 'windows-nt)
+    ;; Windows: Check for standard command prompt / PowerShell markers
+    (not (or
+          (getenv "PROMPT")          ; Exists inside standard Windows cmd.exe
+          (getenv "PSModulePath"))))   ; Exists inside Windows PowerShell / Core
+
+   ;; Linux, macOS: check for POSIX shell identifiers
+   (t (let ((shlvl (getenv "SHLVL")))
+        (and (display-graphic-p)
+             (or (null shlvl)
+                 (equal shlvl "0"))))))) ; Shell Level tracking variable (POSIX shells)
 
 ;; ---------------------------------------------------------------------------
 ;;* Assignment operator macros

--- a/pel--base.el
+++ b/pel--base.el
@@ -516,53 +516,60 @@ has no side-effects.  Returns nil if the information is unavailable."
             (insert-file-contents comm-file)
             (string-trim (buffer-string))))))))
 
+(defvar pel--is-os-launched-gui-p 'unset
+  "Cached value for `pel-is-os-launched-gui-p' returned value.")
+
 (defun pel-is-os-launched-gui-p ()
   "Predicate: t when Emacs is a GUI Emacs launched from the OS, not a shell.
 Returns nil when Emacs is running in terminal mode, or when it was launched
-from a shell (interactively or via a shell script such as bin/ec)."
-  (when (display-graphic-p)
-    (cond
-     ;; Windows
-     ((eq system-type 'windows-nt)
-      ;; PROMPT      → set only inside an active cmd.exe session
-      ;; PSModulePath is system-wide (set at PS installation), but
-      ;; PSVersionTable is session-only → both present = active PS session
-      ;; SHLVL       → set by Git Bash / MSYS2 / Cygwin shells
-      (not (or (getenv "PROMPT")
-               (and (getenv "PSModulePath")
-                    (getenv "PSVersionTable"))
-               (getenv "SHLVL"))))
-
-     ;;
-     ;; GNU/Linux — exact check via /proc (no subprocess, O(1) cost)
-     ((eq system-type 'gnu/linux)
-      (let ((parent (pel--linux-parent-process-name)))
-        (if parent
-            ;; Definitive: true only when the parent is NOT a known shell
-            (not (member parent pel--known-shells))
-          ;; /proc/<ppid>/comm unreadable (container / restricted namespace):
-          ;; fall back to env-var heuristics
-          (let ((shlvl (getenv "SHLVL")))
-            (and (or (null shlvl) (equal shlvl "0"))
-                 (not (or (getenv "TERM_PROGRAM")
-                          (getenv "COLORTERM")
-                          (getenv "SSH_TTY"))))))))
-
-     ;;
-     ;; macOS, *BSD, and other Unix-like systems
-     ;; A ps-based parent-process check would be exact but spawns a
-     ;; subprocess at startup; env-var heuristics are used instead.
-     ;; macOS launchd sets TERM=dumb for GUI apps launched from the desktop;
-     ;; every real terminal emulator sets a meaningful value (xterm-256color,
-     ;; alacritty, xterm-kitty, …).
-     (t
-      (let ((shlvl (getenv "SHLVL"))
-            (term  (getenv "TERM")))
-        (and (or (null shlvl) (equal shlvl "0"))
-             (or (null term)  (equal term "dumb"))
-             (not (or (getenv "TERM_PROGRAM") ; Terminal.app, iTerm2, VSCode…
-                      (getenv "COLORTERM")    ; Alacritty, Kitty (true-colour)
-                      (getenv "SSH_TTY")))))))))
+from a shell (interactively or via a shell script such as bin/ec).
+The computation is done once and its result is cached.  The cached value
+returned in subsequent calls."
+  (if (eq pel--is-os-launched-gui-p 'unset)
+      (setq
+       pel--is-os-launched-gui-p
+       (when (display-graphic-p)
+         (cond
+          ;; Windows
+          ((eq system-type 'windows-nt)
+           ;; PROMPT    → active cmd.exe session
+           ;; PSHOME    → active PowerShell session (session-scoped env var)
+           ;; SHLVL     → Git Bash / MSYS2 / Cygwin
+           ;; WT_SESSION → Windows Terminal (any shell inside it)
+           (not (or (getenv "PROMPT")
+                    (getenv "PSHOME")
+                    (getenv "SHLVL")
+                    (getenv "WT_SESSION"))))
+          ;;
+          ;; GNU/Linux — exact check via /proc (no subprocess, O(1) cost)
+          ((eq system-type 'gnu/linux)
+           (let ((parent (pel--linux-parent-process-name)))
+             (if parent
+                 ;; Definitive: true only when the parent is NOT a known shell
+                 (not (member parent pel--known-shells))
+               ;; /proc/<ppid>/comm unreadable (container / restricted namespace):
+               ;; fall back to env-var heuristics
+               (let ((shlvl (getenv "SHLVL")))
+                 (and (or (null shlvl) (equal shlvl "0"))
+                      (not (or (getenv "TERM_PROGRAM")
+                               (getenv "COLORTERM")
+                               (getenv "SSH_TTY"))))))))
+          ;;
+          ;; macOS, *BSD, and other Unix-like systems
+          ;; A ps-based parent-process check would be exact but spawns a
+          ;; subprocess at startup; env-var heuristics are used instead.
+          ;; macOS launchd sets TERM=dumb for GUI apps launched from the desktop;
+          ;; every real terminal emulator sets a meaningful value (xterm-256color,
+          ;; alacritty, xterm-kitty, …).
+          (t
+           (let ((shlvl (getenv "SHLVL"))
+                 (term  (getenv "TERM")))
+             (and (or (null shlvl) (equal shlvl "0"))
+                  (or (null term)  (equal term "dumb"))
+                  (not (or (getenv "TERM_PROGRAM") ; Terminal.app, iTerm2, VSCode…
+                           (getenv "COLORTERM") ; Alacritty, Kitty (true-colour)
+                           (getenv "SSH_TTY")))))))))
+    pel--is-os-launched-gui-p))
 
 ;; ---------------------------------------------------------------------------
 ;;* Assignment operator macros

--- a/pel--base.el
+++ b/pel--base.el
@@ -523,52 +523,62 @@ has no side-effects.  Returns nil if the information is unavailable."
   "Predicate: t when Emacs is a GUI Emacs launched from the OS, not a shell.
 Returns nil when Emacs is running in terminal mode, or when it was launched
 from a shell (interactively or via a shell script such as bin/ec).
+
+If `pel-emacs-gui-programs' is non-nil, the current executable path is
+checked against it first; if it matches, t is returned without heuristics.
+
 The computation is done once and its result is cached.  The cached value
 returned in subsequent calls."
   (if (eq pel--is-os-launched-gui-p 'unset)
       (setq
        pel--is-os-launched-gui-p
        (when (display-graphic-p)
-         (cond
-          ;; Windows
-          ((eq system-type 'windows-nt)
-           ;; PROMPT    → active cmd.exe session
-           ;; PSHOME    → active PowerShell session (session-scoped env var)
-           ;; SHLVL     → Git Bash / MSYS2 / Cygwin
-           ;; WT_SESSION → Windows Terminal (any shell inside it)
-           (not (or (getenv "PROMPT")
-                    (getenv "PSHOME")
-                    (getenv "SHLVL")
-                    (getenv "WT_SESSION"))))
-          ;;
-          ;; GNU/Linux — exact check via /proc (no subprocess, O(1) cost)
-          ((eq system-type 'gnu/linux)
-           (let ((parent (pel--linux-parent-process-name)))
-             (if parent
-                 ;; Definitive: true only when the parent is NOT a known shell
-                 (not (member parent pel--known-shells))
-               ;; /proc/<ppid>/comm unreadable (container / restricted namespace):
-               ;; fall back to env-var heuristics
-               (let ((shlvl (getenv "SHLVL")))
-                 (and (or (null shlvl) (equal shlvl "0"))
-                      (not (or (getenv "TERM_PROGRAM")
-                               (getenv "COLORTERM")
-                               (getenv "SSH_TTY"))))))))
-          ;;
-          ;; macOS, *BSD, and other Unix-like systems
-          ;; A ps-based parent-process check would be exact but spawns a
-          ;; subprocess at startup; env-var heuristics are used instead.
-          ;; macOS launchd sets TERM=dumb for GUI apps launched from the desktop;
-          ;; every real terminal emulator sets a meaningful value (xterm-256color,
-          ;; alacritty, xterm-kitty, …).
-          (t
-           (let ((shlvl (getenv "SHLVL"))
-                 (term  (getenv "TERM")))
-             (and (or (null shlvl) (equal shlvl "0"))
-                  (or (null term)  (equal term "dumb"))
-                  (not (or (getenv "TERM_PROGRAM") ; Terminal.app, iTerm2, VSCode…
-                           (getenv "COLORTERM") ; Alacritty, Kitty (true-colour)
-                           (getenv "SSH_TTY")))))))))
+         (or
+          ;; Stage 1 – user-configured executable paths (100 % reliable)
+          (when pel-emacs-gui-programs
+            (let ((exe (expand-file-name invocation-name invocation-directory)))
+              (and (member exe pel-emacs-gui-programs) t)))
+          ;; Stage 2 – OS/environment heuristics (fallback)
+          (cond
+           ;; Windows
+           ((eq system-type 'windows-nt)
+            ;; PROMPT    → active cmd.exe session
+            ;; PSHOME    → active PowerShell session (session-scoped env var)
+            ;; SHLVL     → Git Bash / MSYS2 / Cygwin
+            ;; WT_SESSION → Windows Terminal (any shell inside it)
+            (not (or (getenv "PROMPT")
+                     (getenv "PSHOME")
+                     (getenv "SHLVL")
+                     (getenv "WT_SESSION"))))
+           ;;
+           ;; GNU/Linux — exact check via /proc (no subprocess, O(1) cost)
+           ((eq system-type 'gnu/linux)
+            (let ((parent (pel--linux-parent-process-name)))
+              (if parent
+                  ;; Definitive: true only when the parent is NOT a known shell
+                  (not (member parent pel--known-shells))
+                ;; /proc/<ppid>/comm unreadable (container / restricted namespace):
+                ;; fall back to env-var heuristics
+                (let ((shlvl (getenv "SHLVL")))
+                  (and (or (null shlvl) (equal shlvl "0"))
+                       (not (or (getenv "TERM_PROGRAM")
+                                (getenv "COLORTERM")
+                                (getenv "SSH_TTY"))))))))
+           ;;
+           ;; macOS, *BSD, and other Unix-like systems
+           ;; A ps-based parent-process check would be exact but spawns a
+           ;; subprocess at startup; env-var heuristics are used instead.
+           ;; macOS launchd sets TERM=dumb for GUI apps launched from the desktop;
+           ;; every real terminal emulator sets a meaningful value (xterm-256color,
+           ;; alacritty, xterm-kitty, …).
+           (t
+            (let ((shlvl (getenv "SHLVL"))
+                  (term  (getenv "TERM")))
+              (and (or (null shlvl) (equal shlvl "0"))
+                   (or (null term)  (equal term "dumb"))
+                   (not (or (getenv "TERM_PROGRAM") ; Terminal.app, iTerm2, VSCode…
+                            (getenv "COLORTERM") ; Alacritty, Kitty (true-colour)
+                            (getenv "SSH_TTY"))))))))))
     pel--is-os-launched-gui-p))
 
 ;; ---------------------------------------------------------------------------

--- a/pel--base.el
+++ b/pel--base.el
@@ -470,25 +470,99 @@ Other uses risk returning non-nil value that point to the wrong file."
   (and (eq system-type 'darwin)
        (not (display-graphic-p))))
 
+
+;; (defun pel-is-os-launched-gui-p ()
+;;   "Predicate: t when Emacs is a GUI Emacs launched from the OS, not a shell."
+;;   (when (display-graphic-p)
+;;     (cond
+;;      ((eq system-type 'windows-nt)
+;;       ;; Windows: detect terminal/session-launched GUI via shell/session markers.
+;;       (not (or (getenv "PROMPT")        ; cmd.exe
+;;                (getenv "SHLVL")         ; MSYS2/Cygwin/Git Bash
+;;                (getenv "MSYSTEM")
+;;                (getenv "WT_SESSION")
+;;                (getenv "TERM"))))
+;;
+;;      ;; Linux, macOS: check for POSIX shell identifiers
+;;      (t
+;;       (let ((shlvl (getenv "SHLVL")))
+;;         ;; OS-launched GUI only when no terminal/remote markers are present.
+;;         (and (not (or (getenv "TERM")
+;;                       (getenv "TERM_PROGRAM")
+;;                       (getenv "COLORTERM")
+;;                       (getenv "SSH_TTY")
+;;                       (getenv "SSH_CLIENT")))
+;;              (or (null shlvl) (equal shlvl "0"))))))))
+
+(defconst pel--known-shells
+  '("bash" "zsh" "sh" "dash" "fish" "ksh" "tcsh" "csh" "ash" "mksh" "pdksh"
+    "elvish" "nu" "ion" "yash" "rbash" "rzsh")
+  "Common Unix shell executable names used by `pel-is-os-launched-gui-p'.")
+
+(defun pel--linux-parent-process-name ()
+  "Return the parent process executable name on Linux via /proc.
+Reads /proc/self/status to obtain the PPid, then reads /proc/<ppid>/comm
+for the executable name.  No subprocess is spawned; this is fast and
+has no side-effects.  Returns nil if the information is unavailable."
+  (let ((ppid
+         (with-temp-buffer
+           (insert-file-contents "/proc/self/status")
+           (when (re-search-forward "^PPid:[ \t]+\\([0-9]+\\)" nil t)
+             (match-string 1)))))
+    (when ppid
+      (let ((comm-file (format "/proc/%s/comm" ppid)))
+        (when (file-readable-p comm-file)
+          (with-temp-buffer
+            (insert-file-contents comm-file)
+            (string-trim (buffer-string))))))))
+
 (defun pel-is-os-launched-gui-p ()
-  "Predicate: t when Emacs is a GUI Emacs launched from the OS, not a shell."
+  "Predicate: t when Emacs is a GUI Emacs launched from the OS, not a shell.
+Returns nil when Emacs is running in terminal mode, or when it was launched
+from a shell (interactively or via a shell script such as bin/ec)."
   (when (display-graphic-p)
     (cond
+     ;; Windows
      ((eq system-type 'windows-nt)
-      ;; Windows: Check for standard command prompt / PowerShell markers
-      (not (or (getenv "PROMPT")        ; cmd.exe session
-               ;; Check for active PS session, not just installation:
+      ;; PROMPT      → set only inside an active cmd.exe session
+      ;; PSModulePath is system-wide (set at PS installation), but
+      ;; PSVersionTable is session-only → both present = active PS session
+      ;; SHLVL       → set by Git Bash / MSYS2 / Cygwin shells
+      (not (or (getenv "PROMPT")
                (and (getenv "PSModulePath")
-                    (getenv "PSVersionTable")) ; only set in active PS session
-               (getenv "SHLVL"))))             ; Git Bash / MSYS2 / Cygwin
+                    (getenv "PSVersionTable"))
+               (getenv "SHLVL"))))
 
-     ;; Linux, macOS: check for POSIX shell identifiers
-     (t (let ((shlvl (getenv "SHLVL")))
-          ;;  Shell Level tracking variable (POSIX shells)
-          (and (or (null shlvl) (equal shlvl "0"))
-               (not (or (getenv "TERM_PROGRAM")
-                        (getenv "COLORTERM")
-                        (getenv "SSH_TTY")))))))))
+     ;;
+     ;; GNU/Linux — exact check via /proc (no subprocess, O(1) cost)
+     ((eq system-type 'gnu/linux)
+      (let ((parent (pel--linux-parent-process-name)))
+        (if parent
+            ;; Definitive: true only when the parent is NOT a known shell
+            (not (member parent pel--known-shells))
+          ;; /proc/<ppid>/comm unreadable (container / restricted namespace):
+          ;; fall back to env-var heuristics
+          (let ((shlvl (getenv "SHLVL")))
+            (and (or (null shlvl) (equal shlvl "0"))
+                 (not (or (getenv "TERM_PROGRAM")
+                          (getenv "COLORTERM")
+                          (getenv "SSH_TTY"))))))))
+
+     ;;
+     ;; macOS, *BSD, and other Unix-like systems
+     ;; A ps-based parent-process check would be exact but spawns a
+     ;; subprocess at startup; env-var heuristics are used instead.
+     ;; macOS launchd sets TERM=dumb for GUI apps launched from the desktop;
+     ;; every real terminal emulator sets a meaningful value (xterm-256color,
+     ;; alacritty, xterm-kitty, …).
+     (t
+      (let ((shlvl (getenv "SHLVL"))
+            (term  (getenv "TERM")))
+        (and (or (null shlvl) (equal shlvl "0"))
+             (or (null term)  (equal term "dumb"))
+             (not (or (getenv "TERM_PROGRAM") ; Terminal.app, iTerm2, VSCode…
+                      (getenv "COLORTERM")    ; Alacritty, Kitty (true-colour)
+                      (getenv "SSH_TTY")))))))))
 
 ;; ---------------------------------------------------------------------------
 ;;* Assignment operator macros

--- a/pel--base.el
+++ b/pel--base.el
@@ -36,7 +36,6 @@
 ;; Emacs TTY/Graphics Mode Detection
 ;; - `pel-emacs-is-a-tty-p'
 ;; - `pel-can-display-special-chars-p'
-;; - `pel-is-os-launched-gui-p'
 ;;
 ;; Assignment operator macros
 ;;  - `pel+='
@@ -469,117 +468,6 @@ Other uses risk returning non-nil value that point to the wrong file."
   "Predicate: t if Emacs can properly show Unicode characters like 👍 or 👎."
   (and (eq system-type 'darwin)
        (not (display-graphic-p))))
-
-
-;; (defun pel-is-os-launched-gui-p ()
-;;   "Predicate: t when Emacs is a GUI Emacs launched from the OS, not a shell."
-;;   (when (display-graphic-p)
-;;     (cond
-;;      ((eq system-type 'windows-nt)
-;;       ;; Windows: detect terminal/session-launched GUI via shell/session markers.
-;;       (not (or (getenv "PROMPT")        ; cmd.exe
-;;                (getenv "SHLVL")         ; MSYS2/Cygwin/Git Bash
-;;                (getenv "MSYSTEM")
-;;                (getenv "WT_SESSION")
-;;                (getenv "TERM"))))
-;;
-;;      ;; Linux, macOS: check for POSIX shell identifiers
-;;      (t
-;;       (let ((shlvl (getenv "SHLVL")))
-;;         ;; OS-launched GUI only when no terminal/remote markers are present.
-;;         (and (not (or (getenv "TERM")
-;;                       (getenv "TERM_PROGRAM")
-;;                       (getenv "COLORTERM")
-;;                       (getenv "SSH_TTY")
-;;                       (getenv "SSH_CLIENT")))
-;;              (or (null shlvl) (equal shlvl "0"))))))))
-
-(defconst pel--known-shells
-  '("bash" "zsh" "sh" "dash" "fish" "ksh" "tcsh" "csh" "ash" "mksh" "pdksh"
-    "elvish" "nu" "ion" "yash" "rbash" "rzsh")
-  "Common Unix shell executable names used by `pel-is-os-launched-gui-p'.")
-
-(defun pel--linux-parent-process-name ()
-  "Return the parent process executable name on Linux via /proc.
-Reads /proc/self/status to obtain the PPid, then reads /proc/<ppid>/comm
-for the executable name.  No subprocess is spawned; this is fast and
-has no side-effects.  Returns nil if the information is unavailable."
-  (let ((ppid
-         (with-temp-buffer
-           (insert-file-contents "/proc/self/status")
-           (when (re-search-forward "^PPid:[ \t]+\\([0-9]+\\)" nil t)
-             (match-string 1)))))
-    (when ppid
-      (let ((comm-file (format "/proc/%s/comm" ppid)))
-        (when (file-readable-p comm-file)
-          (with-temp-buffer
-            (insert-file-contents comm-file)
-            (string-trim (buffer-string))))))))
-
-(defvar pel--is-os-launched-gui-p 'unset
-  "Cached value for `pel-is-os-launched-gui-p' returned value.")
-
-(defun pel-is-os-launched-gui-p ()
-  "Predicate: t when Emacs is a GUI Emacs launched from the OS, not a shell.
-Returns nil when Emacs is running in terminal mode, or when it was launched
-from a shell (interactively or via a shell script such as bin/ec).
-
-If `pel-emacs-gui-programs' is non-nil, the current executable path is
-checked against it first; if it matches, t is returned without heuristics.
-
-The computation is done once and its result is cached.  The cached value
-returned in subsequent calls."
-  (if (eq pel--is-os-launched-gui-p 'unset)
-      (setq
-       pel--is-os-launched-gui-p
-       (when (display-graphic-p)
-         (or
-          ;; Stage 1 – user-configured executable paths (100 % reliable)
-          (when pel-emacs-gui-programs
-            (let ((exe (expand-file-name invocation-name invocation-directory)))
-              (and (member exe pel-emacs-gui-programs) t)))
-          ;; Stage 2 – OS/environment heuristics (fallback)
-          (cond
-           ;; Windows
-           ((eq system-type 'windows-nt)
-            ;; PROMPT    → active cmd.exe session
-            ;; PSHOME    → active PowerShell session (session-scoped env var)
-            ;; SHLVL     → Git Bash / MSYS2 / Cygwin
-            ;; WT_SESSION → Windows Terminal (any shell inside it)
-            (not (or (getenv "PROMPT")
-                     (getenv "PSHOME")
-                     (getenv "SHLVL")
-                     (getenv "WT_SESSION"))))
-           ;;
-           ;; GNU/Linux — exact check via /proc (no subprocess, O(1) cost)
-           ((eq system-type 'gnu/linux)
-            (let ((parent (pel--linux-parent-process-name)))
-              (if parent
-                  ;; Definitive: true only when the parent is NOT a known shell
-                  (not (member parent pel--known-shells))
-                ;; /proc/<ppid>/comm unreadable (container / restricted namespace):
-                ;; fall back to env-var heuristics
-                (let ((shlvl (getenv "SHLVL")))
-                  (and (or (null shlvl) (equal shlvl "0"))
-                       (not (or (getenv "TERM_PROGRAM")
-                                (getenv "COLORTERM")
-                                (getenv "SSH_TTY"))))))))
-           ;;
-           ;; macOS, *BSD, and other Unix-like systems
-           ;; A ps-based parent-process check would be exact but spawns a
-           ;; subprocess at startup; env-var heuristics are used instead.
-           ;; macOS launchd sets TERM=dumb for GUI apps launched from the desktop;
-           ;; every real terminal emulator sets a meaningful value (xterm-256color,
-           ;; alacritty, xterm-kitty, …).
-           (t
-            (let ((shlvl (getenv "SHLVL"))
-                  (term  (getenv "TERM")))
-              (and (or (null shlvl) (equal shlvl "0"))
-                   (or (null term)  (equal term "dumb"))
-                   (not (or (getenv "TERM_PROGRAM") ; Terminal.app, iTerm2, VSCode…
-                            (getenv "COLORTERM") ; Alacritty, Kitty (true-colour)
-                            (getenv "SSH_TTY"))))))))))
-    pel--is-os-launched-gui-p))
 
 ;; ---------------------------------------------------------------------------
 ;;* Assignment operator macros

--- a/pel--base.el
+++ b/pel--base.el
@@ -472,18 +472,23 @@ Other uses risk returning non-nil value that point to the wrong file."
 
 (defun pel-is-os-launched-gui-p ()
   "Predicate: t when Emacs is a GUI Emacs launched from the OS, not a shell."
-  (cond
-   ((eq system-type 'windows-nt)
-    ;; Windows: Check for standard command prompt / PowerShell markers
-    (not (or
-          (getenv "PROMPT")          ; Exists inside standard Windows cmd.exe
-          (getenv "PSModulePath"))))   ; Exists inside Windows PowerShell / Core
+  (when (display-graphic-p)
+    (cond
+     ((eq system-type 'windows-nt)
+      ;; Windows: Check for standard command prompt / PowerShell markers
+      (not (or (getenv "PROMPT")        ; cmd.exe session
+               ;; Check for active PS session, not just installation:
+               (and (getenv "PSModulePath")
+                    (getenv "PSVersionTable")) ; only set in active PS session
+               (getenv "SHLVL"))))             ; Git Bash / MSYS2 / Cygwin
 
-   ;; Linux, macOS: check for POSIX shell identifiers
-   (t (let ((shlvl (getenv "SHLVL")))
-        (and (display-graphic-p)
-             (or (null shlvl)
-                 (equal shlvl "0"))))))) ; Shell Level tracking variable (POSIX shells)
+     ;; Linux, macOS: check for POSIX shell identifiers
+     (t (let ((shlvl (getenv "SHLVL")))
+          ;;  Shell Level tracking variable (POSIX shells)
+          (and (or (null shlvl) (equal shlvl "0"))
+               (not (or (getenv "TERM_PROGRAM")
+                        (getenv "COLORTERM")
+                        (getenv "SSH_TTY")))))))))
 
 ;; ---------------------------------------------------------------------------
 ;;* Assignment operator macros

--- a/pel--options.el
+++ b/pel--options.el
@@ -890,7 +890,8 @@ Note: `display-graphic-p' is still checked, so a terminal-mode Emacs using
 the same binary will never return t."
   :group 'pel-base-emacs
   :group 'pel-fast-startup
-  :type '(repeat file))
+  :type '(repeat file)
+  :safe #'listp)
 
 
 (defcustom pel-shell-detection-envvar "OBSOLETE-DO-NOT-USE!"

--- a/pel--options.el
+++ b/pel--options.el
@@ -873,21 +873,30 @@ Use this is a tool to help debug syntax processing of major modes."
   :link `(url-link :tag "Fast Startup PDF" ,(pel-pdf-file-url "fast-startup"))
   :group 'pel)
 
-(defcustom pel-shell-detection-envvar "_"
+(defcustom pel-emacs-gui-programs nil
+  "List of absolute paths of Emacs executables known to be pure GUI programs.
+When non-nil, `pel-is-os-launched-gui-p' returns t immediately if the
+running Emacs executable matches any listed path, bypassing the
+platform-specific heuristics entirely.
+
+Typical use cases:
+- macOS: add the path inside the .app bundle, e.g.
+    \"/Applications/Emacs.app/Contents/MacOS/Emacs\"
+  (this binary is never invoked directly from a shell, so the match is exact).
+- Linux: a dedicated GUI-only build, e.g. \"/opt/emacs-gui/bin/emacs\".
+- Windows: a dedicated GUI build, e.g. \"C:/emacs-gui/bin/emacs.exe\".
+
+Note: `display-graphic-p' is still checked, so a terminal-mode Emacs using
+the same binary will never return t."
+  :group 'pel-base-emacs
+  :group 'pel-fast-startup
+  :type '(repeat file))
+
+
+(defcustom pel-shell-detection-envvar "OBSOLETE-DO-NOT-USE!"
   "Name of envvar used to detect that Emacs was launched by a shell.
 
-The default is \"_\", the environment variable that Bash uses to
-identify the name of the executable that launched it.  This
-environment variable is not part of the process environment when
-Emacs is launched from a GUI program such as macOS Finder.
-
-Change this value when using another shell or when running on
-other operating system such as Windows.  If you cannot find a
-suitable environment variable that is defined when Emacs is
-launched, then define an environment variable that will be
-present in all instances of your shell but not inside the OS
-process environment.  For instance you could use the environment
-name \"PEL_SHELL\"."
+OBSOLETE user-option no longer used. Delete it from your customization."
   :group 'pel-fast-startup
   :type 'string)
 
@@ -927,10 +936,9 @@ IMPORTANT NOTES
 
 These environment variables are only used for a GUI-launched
 Emacs session; an Emacs session that has not been launched by a
-shell.  PEL detects this type of Emacs session when it detects
-that the environment variable identified by
-`pel-shell-detection-envvar' is not present inside the process
-environment.
+shell.  The `pel-is-os-launched-gui-p' function detects this
+type of Emacs session and uses the `pel-emacs-gui-programs'
+user-option to reliably identify them.
 
 PEL sets Emacs environment variable process **once** per process
 execution session, during the **first** call of function

--- a/pel--process.el
+++ b/pel--process.el
@@ -1,0 +1,130 @@
+;;; pel--process.el --- PEL Emacs Type Detection Logic  -*- lexical-binding: t; -*-
+
+;; Created   : Monday, May 25 2026.
+;; Author    : Pierre Rouleau <prouleau001@gmail.com>
+;; Time-stamp: <2026-05-25 18:13:51 EDT, updated by Pierre Rouleau>
+
+;; This file is part of the PEL package.
+;; This file is not part of GNU Emacs.
+
+;; Copyright (C) 2026  Pierre Rouleau
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; --------------------------------------------------------------------------
+;;; Commentary:
+;;
+;; Defines a function to detect whether a GUI Emacs was launched directly from
+;; the OS instead of a shell.
+
+;;; --------------------------------------------------------------------------
+;;; Dependencies:
+;;
+;;
+(require 'pel--options)
+;;; --------------------------------------------------------------------------
+;;; Code:
+;;
+
+(defconst pel--known-shells
+  '("bash" "zsh" "sh" "dash" "fish" "ksh" "tcsh" "csh" "ash" "mksh" "pdksh"
+    "elvish" "nu" "ion" "yash" "rbash" "rzsh")
+  "Common Unix shell executable names used by `pel-is-os-launched-gui-p'.")
+
+(defun pel--linux-parent-process-name ()
+  "Return the parent process executable name on Linux via /proc.
+Reads /proc/self/status to obtain the PPid, then reads /proc/<ppid>/comm
+for the executable name.  No subprocess is spawned; this is fast and
+has no side-effects.  Returns nil if the information is unavailable."
+  (let ((ppid
+         (with-temp-buffer
+           (insert-file-contents "/proc/self/status")
+           (when (re-search-forward "^PPid:[ \t]+\\([0-9]+\\)" nil t)
+             (match-string 1)))))
+    (when ppid
+      (let ((comm-file (format "/proc/%s/comm" ppid)))
+        (when (file-readable-p comm-file)
+          (with-temp-buffer
+            (insert-file-contents comm-file)
+            (string-trim (buffer-string))))))))
+
+(defvar pel--is-os-launched-gui-p 'unset
+  "Cached value for `pel-is-os-launched-gui-p' returned value.")
+
+(defun pel-is-os-launched-gui-p ()
+  "Predicate: t when Emacs is a GUI Emacs launched from the OS, not a shell.
+Returns nil when Emacs is running in terminal mode, or when it was launched
+from a shell (interactively or via a shell script such as bin/ec).
+
+If `pel-emacs-gui-programs' is non-nil, the current executable path is
+checked against it first; if it matches, t is returned without heuristics.
+
+The computation is done once and its result is cached.  The cached value
+returned in subsequent calls."
+  (if (eq pel--is-os-launched-gui-p 'unset)
+      (setq
+       pel--is-os-launched-gui-p
+       (when (display-graphic-p)
+         (or
+          ;; Stage 1 – user-configured executable paths (100 % reliable)
+          (when pel-emacs-gui-programs
+            (let ((exe (expand-file-name invocation-name invocation-directory)))
+              (and (member exe pel-emacs-gui-programs) t)))
+          ;; Stage 2 – OS/environment heuristics (fallback)
+          (cond
+           ;; Windows
+           ((eq system-type 'windows-nt)
+            ;; PROMPT    → active cmd.exe session
+            ;; PSHOME    → active PowerShell session (session-scoped env var)
+            ;; SHLVL     → Git Bash / MSYS2 / Cygwin
+            ;; WT_SESSION → Windows Terminal (any shell inside it)
+            (not (or (getenv "PROMPT")
+                     (getenv "PSHOME")
+                     (getenv "SHLVL")
+                     (getenv "WT_SESSION"))))
+           ;;
+           ;; GNU/Linux — exact check via /proc (no subprocess, O(1) cost)
+           ((eq system-type 'gnu/linux)
+            (let ((parent (pel--linux-parent-process-name)))
+              (if parent
+                  ;; Definitive: true only when the parent is NOT a known shell
+                  (not (member parent pel--known-shells))
+                ;; /proc/<ppid>/comm unreadable (container / restricted namespace):
+                ;; fall back to env-var heuristics
+                (let ((shlvl (getenv "SHLVL")))
+                  (and (or (null shlvl) (equal shlvl "0"))
+                       (not (or (getenv "TERM_PROGRAM")
+                                (getenv "COLORTERM")
+                                (getenv "SSH_TTY"))))))))
+           ;;
+           ;; macOS, *BSD, and other Unix-like systems
+           ;; A ps-based parent-process check would be exact but spawns a
+           ;; subprocess at startup; env-var heuristics are used instead.
+           ;; macOS launchd sets TERM=dumb for GUI apps launched from the desktop;
+           ;; every real terminal emulator sets a meaningful value (xterm-256color,
+           ;; alacritty, xterm-kitty, …).
+           (t
+            (let ((shlvl (getenv "SHLVL"))
+                  (term  (getenv "TERM")))
+              (and (or (null shlvl) (equal shlvl "0"))
+                   (or (null term)  (equal term "dumb"))
+                   (not (or (getenv "TERM_PROGRAM") ; Terminal.app, iTerm2, VSCode…
+                            (getenv "COLORTERM") ; Alacritty, Kitty (true-colour)
+                            (getenv "SSH_TTY"))))))))))
+    pel--is-os-launched-gui-p))
+
+;;; --------------------------------------------------------------------------
+(provide 'pel--process)
+
+;;; pel--process.el ends here

--- a/pel-prompt.el
+++ b/pel-prompt.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Saturday, February 29 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-25 13:39:37 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-25 14:59:24 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package
 ;; This file is not part of GNU Emacs.
@@ -574,18 +574,19 @@ minibuffer for editing."
                      ;; PREDICATE
                      'file-exists-p)))
 
-;; ---
+;; ---------------------------------------------------------------------------
+;; Long Prompt
 
 (defun pel-long-prompt-yes-no (msg &optional prompt-msg)
   "Display a long MSG in the *Attention* window and prompt in the echo area.
 PROMPT-MSG is the querying prompt shown in the echo area.
 It defaults to \"Proceed? \".
-The function return t if the answer is positive, nil otherwise."
+The function returns t if the answer is positive, nil otherwise."
   (let ((buf-name "*Attention*")
         reply)
     ;; 1. Create and show the multi-line buffer
     (with-output-to-temp-buffer buf-name
-      (print msg))
+      (princ msg))
     ;; 2. Force Emacs to draw the new window layout immediately
     (sit-for 0)
     ;; 3. Prompt the user, wrapped in unwind-protect to clear the window when done
@@ -593,10 +594,12 @@ The function return t if the answer is positive, nil otherwise."
         (setq reply (y-or-n-p (format "See *Attention* buffer: %s"
                                       (or prompt-msg "Proceed? "))))
 
-      ;; 4. Always close the message window when done, even if C-g is pressed
+      ;; 4. Close the message window when done, even if C-g is pressed
       (let ((win (get-buffer-window buf-name)))
-        (when win
-          (delete-window win))))
+        (when (window-deletable-p win)
+          (delete-window win))
+        (when (get-buffer buf-name)
+          (kill-buffer buf-name))))
     reply))
 
 ;; -----------------------------------------------------------------------------

--- a/pel-prompt.el
+++ b/pel-prompt.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Saturday, February 29 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-04-16 08:46:28 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-25 13:39:37 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package
 ;; This file is not part of GNU Emacs.
@@ -45,6 +45,7 @@
 ;; - `pel-prompt-with-completion'
 ;; - `pel-prompt-title'
 ;; - `pel-prompt-for-filename'
+;; - `pel-long-prompt-yes-no'
 ;;
 ;; The `pel-y-n-e-or-l-p' function is a minor modification of the Emacs'
 ;; y-or-n-p.  It has the ability to type "e" or "E" as an answer to
@@ -73,6 +74,10 @@
 ;; provides a completion from the choices given in a collection list.
 ;;
 ;; The `pel-prompt-title' is a specialized prompt for a title string.
+;;
+;; Use the `pel-long-prompt-yes-no' when you must prompt with a very long
+;; message. That message is printed inside its own temporary window and then
+;; the prompt is shown in the echo area referring to that window.
 
 ;;; --------------------------------------------------------------------------
 ;;; Dependencies
@@ -86,6 +91,7 @@
   (require 'cl-macs))                 ; use: `cl-case'.
 
 
+;; ---------------------------------------------------------------------------
 ;;; Code:
 
 (defvar pel-prompt-map
@@ -567,6 +573,32 @@ minibuffer for editing."
                      nil
                      ;; PREDICATE
                      'file-exists-p)))
+
+;; ---
+
+(defun pel-long-prompt-yes-no (msg &optional prompt-msg)
+  "Display a long MSG in the *Attention* window and prompt in the echo area.
+PROMPT-MSG is the querying prompt shown in the echo area.
+It defaults to \"Proceed? \".
+The function return t if the answer is positive, nil otherwise."
+  (let ((buf-name "*Attention*")
+        reply)
+    ;; 1. Create and show the multi-line buffer
+    (with-output-to-temp-buffer buf-name
+      (print msg))
+    ;; 2. Force Emacs to draw the new window layout immediately
+    (sit-for 0)
+    ;; 3. Prompt the user, wrapped in unwind-protect to clear the window when done
+    (unwind-protect
+        (setq reply (y-or-n-p (format "See *Attention* buffer: %s"
+                                      (or prompt-msg "Proceed? "))))
+
+      ;; 4. Always close the message window when done, even if C-g is pressed
+      (let ((win (get-buffer-window buf-name)))
+        (when win
+          (delete-window win))))
+    reply))
+
 ;; -----------------------------------------------------------------------------
 (provide 'pel-prompt)
 

--- a/pel-prompt.el
+++ b/pel-prompt.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Saturday, February 29 2020.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-25 14:59:24 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-25 15:04:17 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package
 ;; This file is not part of GNU Emacs.
@@ -596,7 +596,8 @@ The function returns t if the answer is positive, nil otherwise."
 
       ;; 4. Close the message window when done, even if C-g is pressed
       (let ((win (get-buffer-window buf-name)))
-        (when (window-deletable-p win)
+        (when (and win
+                   (window-deletable-p win))
           (delete-window win))
         (when (get-buffer buf-name)
           (kill-buffer buf-name))))

--- a/pel-setup-27.el
+++ b/pel-setup-27.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-19 16:40:37 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-25 17:07:26 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -171,8 +171,8 @@ The behaviour is controlled by:
 - The value of `pel-detected-dual-environment-in-init-p' determines
   whether PEL is used with a dual environment for terminal/TTY and graphics
   mode or just a single one as usual for Emacs.
-- The value of `pel-shell-detection-envvar' user-option determines what
-  environment variable absence is used to detect GUI launched Emacs."
+- The value of `pel-emacs-gui-programs' user-option identifies the absolute
+  paths of pure GUI launched Emacs."
   (pel-create-early-init-if-missing)
   (let* ((early-init-fname (locate-user-emacs-file "early-init.el"))
          (elc-existed-p    (file-exists-p (concat early-init-fname "c"))))
@@ -182,8 +182,8 @@ The behaviour is controlled by:
       (list 'pel-early-init-support-package-quickstart-p pkg-quickstart)
       (list 'pel-early-init-support-dual-environment-p
             pel-detected-dual-environment-in-init-p)
-      (list 'pel-early-init-shell-detection-envvar
-            pel-shell-detection-envvar))
+      (list 'pel-early-init-emacs-gui-programs
+            pel-emacs-gui-programs))
      (or pel-compile-emacs-early-init elc-existed-p))))
 
 (defun pel--store-with-package-quickstart (value)

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-25 13:36:14 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-25 17:31:55 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -113,7 +113,7 @@ In the current code this is only done by `pel--setup-dual-environment'")
 (defconst pel--expected-init-file-version "0.3.1"
   "Must match what is in the example/init/init.el.")
 
-(defconst pel--expected-early-init-file-version "0.3"
+(defconst pel--expected-early-init-file-version "0.4"
   "Must match what is in the example/init/early-init.el.")
 
 ;; --

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-25 10:49:14 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-25 13:36:14 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -373,7 +373,8 @@ Optional arguments:
  You may experience inconsistent Emacs behaviour.  It's best to restart Emacs!"
                  mode)
       (cond ((eq mode 'fast)
-             (display-message-or-buffer "\
+             (display-message-or-buffer
+              (format "\
 PEL/Emacs %soperates in fast startup mode%s.
  Emacs starts faster because single directory packages are bundled inside
  a single directory: %selpa-reduced/pel-bundle-YYYYMMDD.hhmm.
@@ -381,11 +382,12 @@ PEL/Emacs %soperates in fast startup mode%s.
  suspended in this mode.  You can still install packages manually via
  M-x list-packages; they land in elpa-reduced and will be migrated to
  elpa-complete automatically when you run M-x pel-setup-normal."
-                                        now-msg
-                                        (pel-prompt-with-quickstart-state "" nil pq-just-modified)
-                                        user-emacs-directory))
+                      now-msg
+                      (pel-prompt-with-quickstart-state "" nil pq-just-modified)
+                      user-emacs-directory)))
             ((eq mode 'normal)
-             (display-message-or-buffer "\
+             (display-message-or-buffer
+              (format "\
 PEL/Emacs %soperates in normal mode%s.
  In this mode Emacs packages are setup the way Emacs normally organizes them.
  You can install new packages and you can use PEL customization to add and
@@ -393,9 +395,9 @@ PEL/Emacs %soperates in normal mode%s.
  With a large number of external packages Emacs normally starts slower
  because of the larger number of directories inside %selpa
  If you want to speed up Emacs startup execute pel-setup-fast."
-                                        now-msg
-                                        (pel-prompt-with-quickstart-state "" nil pq-just-modified)
-                                        user-emacs-directory))
+                      now-msg
+                      (pel-prompt-with-quickstart-state "" nil pq-just-modified)
+                      user-emacs-directory)))
             (t
              (let* ((tc.met-criteria.problems (pel-fast-setup-met-criteria))
                     (met-criteria (nth 1 tc.met-criteria.problems))

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-24 16:34:30 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-25 10:49:14 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -373,27 +373,29 @@ Optional arguments:
  You may experience inconsistent Emacs behaviour.  It's best to restart Emacs!"
                  mode)
       (cond ((eq mode 'fast)
-             (message "PEL/Emacs %soperates in fast startup mode%s.
+             (display-message-or-buffer "\
+PEL/Emacs %soperates in fast startup mode%s.
  Emacs starts faster because single directory packages are bundled inside
  a single directory: %selpa-reduced/pel-bundle-YYYYMMDD.hhmm.
  NOTE: PEL's automatic package management via `pel-use-<XYZ>' customization is
  suspended in this mode.  You can still install packages manually via
  M-x list-packages; they land in elpa-reduced and will be migrated to
  elpa-complete automatically when you run M-x pel-setup-normal."
-                      now-msg
-                      (pel-prompt-with-quickstart-state "" nil pq-just-modified)
-                      user-emacs-directory))
+                                        now-msg
+                                        (pel-prompt-with-quickstart-state "" nil pq-just-modified)
+                                        user-emacs-directory))
             ((eq mode 'normal)
-             (message "PEL/Emacs %soperates in normal mode%s.
+             (display-message-or-buffer "\
+PEL/Emacs %soperates in normal mode%s.
  In this mode Emacs packages are setup the way Emacs normally organizes them.
  You can install new packages and you can use PEL customization to add and
  install new package, or use pel-cleanup to remove the unused ones.
  With a large number of external packages Emacs normally starts slower
  because of the larger number of directories inside %selpa
  If you want to speed up Emacs startup execute pel-setup-fast."
-                      now-msg
-                      (pel-prompt-with-quickstart-state "" nil pq-just-modified)
-                      user-emacs-directory))
+                                        now-msg
+                                        (pel-prompt-with-quickstart-state "" nil pq-just-modified)
+                                        user-emacs-directory))
             (t
              (let* ((tc.met-criteria.problems (pel-fast-setup-met-criteria))
                     (met-criteria (nth 1 tc.met-criteria.problems))

--- a/pel-spell.el
+++ b/pel-spell.el
@@ -113,6 +113,7 @@
 (require 'pel--macros)
 (require 'pel--options)
 (require 'pel-prompt)                   ; use: `pel-prompt'
+(require 'pel--process)                 ; use: `pel-is-os-launched-gui-p'
 
 (eval-when-compile
   (require 'cl-lib)                     ; use: `cl-dolist' and `cl-return'

--- a/pel-spell.el
+++ b/pel-spell.el
@@ -300,18 +300,16 @@ The %s user-option identifies %s as your spell checker program.
                                  var-name program-name
                                  var-name
                                  (pel-string-when
-                                  (not (getenv pel-shell-detection-envvar))
+                                  (pel-is-os-launched-gui-p)
                                   (format "
- - The '%s' environment variable, selected by `pel-shell-detection-envvar' to
-   detect a shell launching of Emacs, is not set in the environment.
-   That indicates that Emacs was launched from a GUI application instead
-   of a shell.  For this environment you will need to do one of the following:
+   This instance of Emacs was launched from a GUI application instead
+   of a shell.  For this environment you need to do one of the following:
    - Identify the complete path of the ispell-compatible in
      `pel-spell-check-tool',  or
    - Update the PATH used by Emacs by specifying an extension of PATH
      inside the `pel-gui-process-environment' user-option that includes
      the directory where your ispell-compatible program is located."
-                                          pel-shell-detection-envvar))
+                                          ))
                                  (getenv "PATH")
                                  pel--spell-error-info-msg)
                          :error)

--- a/pel_keys.el
+++ b/pel_keys.el
@@ -189,7 +189,7 @@
   "Remembers that `pel-init' was called.  DO NOT MODIFY!")
 
 (unless pel--init-called-once
-  (unless (getenv pel-shell-detection-envvar)
+  (when (pel-is-os-launched-gui-p)
     ;; A GUI Emacs is running! Set up its process environment from user-option.
     (when (and (require 'pel-process nil 'noerror)
                (fboundp 'pel-process-update-environment-from))

--- a/pel_keys.el
+++ b/pel_keys.el
@@ -156,6 +156,7 @@
 ;;                      ;      also defines a set of utility functions to deal with
 ;;                      ;      the options: pel-auto-complete-help
 ;;                      ; use: `pel-emacs-is-graphic-p'
+(require 'pel--process) ; use: `pel-is-os-launched-gui-p'
 
 (eval-when-compile
   (require 'cl-macs))   ; use: `cl-eval-when'


### PR DESCRIPTION
* For long messages that may fit in the echo area use display-message-or-buffer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a long-prompt helper that shows extended messages in a temporary attention buffer and prompts for yes/no confirmation.
  * Added a utility to detect when Emacs was launched directly by the OS to drive GUI initialization.

* **Chores**
  * More reliable detection of GUI-launched Emacs so GUI-specific environment/customization is applied appropriately.
  * Updated startup status display to use a different message/display mechanism.

* **Documentation**
  * Extended file docs to reference the new helper and refreshed metadata timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->