### PR TITLE
Broaden support of package names supported

### DIFF
--- a/pel-elpa.el
+++ b/pel-elpa.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Wednesday, June 30 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-18 16:25:14 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-25 21:31:09 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -492,7 +492,7 @@ Example:
 
 Note that the code supports versions inside the name of the elpa directory."
   (let ((basename (file-name-nondirectory (directory-file-name dirname))))
-    (when (string-match "\\`\\([-[:alnum:]+_]+\\)-[0-9.]+\\'" basename)
+    (when (string-match "\\`\\([-[:alnum:]+_]+\\)-[0-9][[:alnum:].]*\\'" basename)
       (match-string 1 basename))))
 
 (defun pel-elpa-package-alist-of-dir (dirpath)

--- a/pel-elpa.el
+++ b/pel-elpa.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Wednesday, June 30 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-25 22:20:21 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-25 22:25:09 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -480,7 +480,7 @@ Matches:
 - Standard MELPA timestamp versions : \"20250209.1933\"
 - Classic semver-style              : \"1.2.3\"
 - Versions with alphanumeric suffix : \"0.9.1pre\", \"0.9.1-pre\",
-                                      \"1.0alpha\", 2.3rc1\"
+                                      \"1.0alpha\", \"2.3rc1\"
 
 Use this constant everywhere a version portion needs to be matched so that
 support for unusual version strings remains consistent across PEL.")

--- a/pel-elpa.el
+++ b/pel-elpa.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Wednesday, June 30 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-25 21:50:13 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-25 22:20:21 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -474,12 +474,13 @@ have no sub-directories."
 ;;   . `pel-elpa-load-pkg-descriptor'
 
 
-(defconst pel-elpa-pkg-version-regexp "[0-9][[:alnum:].]*"
+(defconst pel-elpa-pkg-version-regexp "[0-9][[:alnum:].-]*"
   "Regexp matching the version portion of an Elpa package directory name.
 Matches:
 - Standard MELPA timestamp versions : \"20250209.1933\"
 - Classic semver-style              : \"1.2.3\"
-- Versions with alphanumeric suffix : \"0.9.1pre\", \"1.0alpha\", \"2.3rc1\"
+- Versions with alphanumeric suffix : \"0.9.1pre\", \"0.9.1-pre\",
+                                      \"1.0alpha\", 2.3rc1\"
 
 Use this constant everywhere a version portion needs to be matched so that
 support for unusual version strings remains consistent across PEL.")

--- a/pel-elpa.el
+++ b/pel-elpa.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Wednesday, June 30 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-25 22:25:09 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-25 22:51:44 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -30,6 +30,10 @@
 ;;  well as re-organize the Emacs directory to speed-up Emacs start-up time.
 ;;
 ;;
+;; Package name / version regexp constants:
+;;  - `pel-elpa-pkg-version-regexp'
+;;  - `pel-elpa-pkg-dirname-regexp'
+
 ;; Utilities:
 ;;  - `pel-elpa-name'
 ;;  - `pel-el-files-in'
@@ -490,13 +494,14 @@ support for unusual version strings remains consistent across PEL.")
   "Regexp matching an Elpa package directory basename (name-version).
 Built from `pel-elpa-pkg-version-regexp'.
 Match group 1 captures the package name.
-Examples: \"ztree-20250209.1933\", \"cask-0.9.1pre\", \"ace-link-20241101.1344\".")
+Examples: \"ztree-20250209.1933\", \"cask-0.9.1pre\",
+          \"ace-link-20241101.1344\".")
 
 ;; --
 (defun pel-elpa-package-name-for (dirname)
   "Return the package name for the specific DIRNAME, return nil on error.
 
-The DIRNAME is expected to be a package-name.-version string.
+The DIRNAME is expected to be a package-name-version string.
 This only performs a string manipulation to extract the package name.
 
 Example:
@@ -509,6 +514,9 @@ Example:
   ELISP> (pel-elpa-package-name-for
            \"~/.emacs.d/elpa-1.2/ace-link-20241101.1344\")
   \"ace-link\"
+
+  ELISP> (pel-elpa-package-name-for \"cask-0.9.1pre\")
+  \"cask\"
 
 Note that the code supports versions inside the name of the elpa directory."
   (let ((basename (file-name-nondirectory (directory-file-name dirname))))

--- a/pel-elpa.el
+++ b/pel-elpa.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Wednesday, June 30 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-25 21:31:09 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-25 21:50:13 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -473,6 +473,25 @@ have no sub-directories."
 ;;   . `pel-elpa-package-directories'
 ;;   . `pel-elpa-load-pkg-descriptor'
 
+
+(defconst pel-elpa-pkg-version-regexp "[0-9][[:alnum:].]*"
+  "Regexp matching the version portion of an Elpa package directory name.
+Matches:
+- Standard MELPA timestamp versions : \"20250209.1933\"
+- Classic semver-style              : \"1.2.3\"
+- Versions with alphanumeric suffix : \"0.9.1pre\", \"1.0alpha\", \"2.3rc1\"
+
+Use this constant everywhere a version portion needs to be matched so that
+support for unusual version strings remains consistent across PEL.")
+
+(defconst pel-elpa-pkg-dirname-regexp
+  (concat "\\`\\([-[:alnum:]+_]+\\)-" pel-elpa-pkg-version-regexp "\\'")
+  "Regexp matching an Elpa package directory basename (name-version).
+Built from `pel-elpa-pkg-version-regexp'.
+Match group 1 captures the package name.
+Examples: \"ztree-20250209.1933\", \"cask-0.9.1pre\", \"ace-link-20241101.1344\".")
+
+;; --
 (defun pel-elpa-package-name-for (dirname)
   "Return the package name for the specific DIRNAME, return nil on error.
 
@@ -492,7 +511,7 @@ Example:
 
 Note that the code supports versions inside the name of the elpa directory."
   (let ((basename (file-name-nondirectory (directory-file-name dirname))))
-    (when (string-match "\\`\\([-[:alnum:]+_]+\\)-[0-9][[:alnum:].]*\\'" basename)
+    (when (string-match pel-elpa-pkg-dirname-regexp basename)
       (match-string 1 basename))))
 
 (defun pel-elpa-package-alist-of-dir (dirpath)

--- a/pel-package.el
+++ b/pel-package.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Monday, March 22 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-25 22:44:19 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-25 23:17:21 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -162,6 +162,7 @@
 (require 'pel-elpa)             ; use: `pel-elpa-package-directories'
 ;;                              ;      `pel-el-files-in'
 ;;                              ;      `pel-elpa-pkg-version-regexp'
+;;                              ;      `pel-elpa-pkg-dirname-regexp'
 ;;                              ;      `pel-elpa-package-name-for'
 (require 'cl-lib)               ; use: `cl-remove-if'
 (require 'seq)                  ; use: `seq-filter'
@@ -1319,9 +1320,8 @@ The function assumes that:
 - the last hyphen in the name separates the package name from the package
   version number,
 - every package has the same name,
-- every package number uses the same style of version number: digits
-  representing a YYYYMMDD.HHMMSS sequence or Major.minor or equivalent
-  like 12.23, 12.44, etc. It also accepts alphanumeric suffix."
+- version strings may be numeric (e.g. YYYYMMDD.HHMMSS, 1.2.3) or may
+  include alphanumeric pre-release suffixes (e.g. 0.9.1pre, 1.0alpha)."
   (sort (copy-sequence pkg-dirs)
         (lambda (a b)
           (let ((fn-a (file-name-nondirectory a))

--- a/pel-package.el
+++ b/pel-package.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Monday, March 22 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-20 11:06:50 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-25 22:06:51 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -161,6 +161,8 @@
 (require 'pel-navigate)         ; use: `pel-backward-token-start'
 (require 'pel-elpa)             ; use: `pel-elpa-package-directories'
 ;;                              ;      `pel-el-files-in'
+;;                              ;      `pel-elpa-pkg-version-regexp'
+;;                              ;      `pel-elpa-package-name-for'
 (require 'cl-lib)               ; use: `cl-remove-if'
 (require 'seq)                  ; use: `seq-filter'
 
@@ -1324,11 +1326,12 @@ The function assumes that:
         (lambda (a b)
           (let ((fn-a (file-name-nondirectory a))
                 (fn-b (file-name-nondirectory b)))
-            (let ((v-a (and (string-match "-\\([0-9.]+\\)$" fn-a) (match-string 1 fn-a)))
-                  (v-b (and (string-match "-\\([0-9.]+\\)$" fn-b) (match-string 1 fn-b))))
+            (let* ((ver-re (concat "-\\(" pel-elpa-pkg-version-regexp "\\)$"))
+                   (v-a (and (string-match ver-re fn-a) (match-string 1 fn-a)))
+                   (v-b (and (string-match ver-re fn-b) (match-string 1 fn-b))))
               (cond
                ((and v-a v-b) (version< v-a v-b))
-               (v-b t)      ; a has no version, sort before b
+               (v-b t)               ; a has no version, sort before b
                (t nil))))))); b has no version or neither, keep order
 
 (defun pel-elpa-dirs-for (pkg &optional in-attic)
@@ -1352,8 +1355,9 @@ packages present in the elpa-attic directory."
                         (pel-elpa-attic-dirpath)
                       package-user-dir)
                     :full-path
-                    (format "\\`%s-[0-9-.]+\\'"
-                            (regexp-quote (pel-as-string pkg))))))
+                    (format "\\`%s-%s\\'"
+                            (regexp-quote (pel-as-string pkg))
+                            pel-elpa-pkg-version-regexp))))
 
 (defun pel-move-to-dir (file dir)
   "Move FILE to directory DIR.
@@ -1451,6 +1455,8 @@ Return the number of symbols that were removed from the
 (defun pel-elpa-packages-in-dir (type)
   "Return a list of symbol for all packages present in local Elpa directory.
 
+The TYPE argument is the same as the one for `pel-elpa-dirpath'.
+
 The function search the directory identified by `pel-elpa-dirpath'.
 
 The directory holds sub-directories, one per package/version.
@@ -1459,13 +1465,16 @@ The returned list contains only one symbol identifying the package for each
 version of that package.
 The list of package symbols is sorted by symbol names."
   (let ((elpa-pkg-dir-names  (directory-files
-                              (pel-elpa-dirpath type) nil ".+[0-9-.]+\\'"))
+                              (pel-elpa-dirpath type)
+                              nil
+                              (concat ".+-" pel-elpa-pkg-version-regexp "\\'")))
         (elpa-pkg-names ()))
     (dolist (dir-name elpa-pkg-dir-names)
-      (when (eq 0 (string-match "\\`\\([^ ]+\\)-[0-9-.]+\\'" dir-name))
-        (let ((pkg-name  (intern (match-string 1 dir-name))))
-          (unless (memq pkg-name elpa-pkg-names)
-            (push pkg-name elpa-pkg-names)))))
+      (let ((pkg-name-str (pel-elpa-package-name-for dir-name)))
+        (when pkg-name-str
+          (let ((pkg-name (intern pkg-name-str)))
+            (unless (memq pkg-name elpa-pkg-names)
+              (push pkg-name elpa-pkg-names))))))
     (nreverse elpa-pkg-names)))
 
 (defun pel-elpa-unrequired ()

--- a/pel-package.el
+++ b/pel-package.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Monday, March 22 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-25 22:06:51 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-25 22:44:19 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -1321,7 +1321,7 @@ The function assumes that:
 - every package has the same name,
 - every package number uses the same style of version number: digits
   representing a YYYYMMDD.HHMMSS sequence or Major.minor or equivalent
-  like 12.23, 12.44, etc..."
+  like 12.23, 12.44, etc. It also accepts alphanumeric suffix."
   (sort (copy-sequence pkg-dirs)
         (lambda (a b)
           (let ((fn-a (file-name-nondirectory a))
@@ -1330,9 +1330,15 @@ The function assumes that:
                    (v-a (and (string-match ver-re fn-a) (match-string 1 fn-a)))
                    (v-b (and (string-match ver-re fn-b) (match-string 1 fn-b))))
               (cond
-               ((and v-a v-b) (version< v-a v-b))
-               (v-b t)               ; a has no version, sort before b
-               (t nil))))))); b has no version or neither, keep order
+               ;; Compare version numbers if possible otherwise compare as strings.
+               ((and v-a v-b)
+                (condition-case nil
+                    (version< v-a v-b)
+                  (error (string< v-a v-b))))
+               ;; a has no version, sort before b
+               (v-b t)
+               ;; b has no version or neither, keep order
+               (t nil)))))))
 
 (defun pel-elpa-dirs-for (pkg &optional in-attic)
   "Return a list of directory names for specified package PKG.
@@ -1467,7 +1473,7 @@ The list of package symbols is sorted by symbol names."
   (let ((elpa-pkg-dir-names  (directory-files
                               (pel-elpa-dirpath type)
                               nil
-                              (concat ".+-" pel-elpa-pkg-version-regexp "\\'")))
+                              pel-elpa-pkg-dirname-regexp))
         (elpa-pkg-names ()))
     (dolist (dir-name elpa-pkg-dir-names)
       (let ((pkg-name-str (pel-elpa-package-name-for dir-name)))

--- a/test/pel-elpa-test.el
+++ b/test/pel-elpa-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, September  2 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-25 22:45:54 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-25 23:18:19 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -103,9 +103,8 @@
   (should (string= (pel-elpa-package-name-for "my_pkg-1.0")                "my_pkg"))
   ;; Hyphenated pre-release suffix
   (should (string= (pel-elpa-package-name-for "demo-1.0-pre")              "demo"))
-  ;; Classic semver
+  ;; Package names with classic semver-style versions
   (should (string= (pel-elpa-package-name-for "pel-0.4.1")                 "pel"))
-
   ;; Non-package directory names must return nil
   (should (null (pel-elpa-package-name-for "archives")))
   (should (null (pel-elpa-package-name-for "gnupg")))

--- a/test/pel-elpa-test.el
+++ b/test/pel-elpa-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, September  2 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-02-26 17:14:47 EST, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-25 22:07:43 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -83,6 +83,27 @@
     (should (equal  (pel-el-files-in test-dir)
                     '("file-a.el" "file-b.el" "file-c.el")))))
 
+
+(ert-deftest test-pel-elpa-package-name-for ()
+  "Test `pel-elpa-package-name-for'."
+  ;; Standard MELPA timestamp versions
+  (should (string= (pel-elpa-package-name-for "ztree-20250209.1933")       "ztree"))
+  (should (string= (pel-elpa-package-name-for "ace-link-20241101.1344")    "ace-link"))
+  ;; Full path inputs are also supported
+  (should (string= (pel-elpa-package-name-for
+                    "~/.emacs.d/elpa/ztree-20250209.1933")                  "ztree"))
+  (should (string= (pel-elpa-package-name-for
+                    "~/.emacs.d/elpa-1.2/ace-link-20241101.1344")           "ace-link"))
+  ;; Versions with alphanumeric suffixes (motivation for PR `#168`)
+  (should (string= (pel-elpa-package-name-for "cask-0.9.1pre")             "cask"))
+  (should (string= (pel-elpa-package-name-for "some-pkg-1.0alpha")         "some-pkg"))
+  (should (string= (pel-elpa-package-name-for "other-pkg-2.3rc1")          "other-pkg"))
+  ;; Package names containing + or _ characters
+  (should (string= (pel-elpa-package-name-for "c++-mode-1.0")              "c++-mode"))
+  ;; Non-package directory names must return nil
+  (should (null (pel-elpa-package-name-for "archives")))
+  (should (null (pel-elpa-package-name-for "gnupg")))
+  (should (null (pel-elpa-package-name-for "no-version-here"))))
 
 ;;; --------------------------------------------------------------------------
 (provide 'pel-elpa-test)

--- a/test/pel-elpa-test.el
+++ b/test/pel-elpa-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, September  2 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-25 22:17:56 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-25 22:45:54 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -100,10 +100,11 @@
   (should (string= (pel-elpa-package-name-for "other-pkg-2.3rc1")          "other-pkg"))
   ;; Package names containing + or _ characters
   (should (string= (pel-elpa-package-name-for "c++-mode-1.0")              "c++-mode"))
-
   (should (string= (pel-elpa-package-name-for "my_pkg-1.0")                "my_pkg"))
   ;; Hyphenated pre-release suffix
   (should (string= (pel-elpa-package-name-for "demo-1.0-pre")              "demo"))
+  ;; Classic semver
+  (should (string= (pel-elpa-package-name-for "pel-0.4.1")                 "pel"))
 
   ;; Non-package directory names must return nil
   (should (null (pel-elpa-package-name-for "archives")))

--- a/test/pel-elpa-test.el
+++ b/test/pel-elpa-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, September  2 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-25 22:07:43 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-25 22:17:56 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -100,6 +100,11 @@
   (should (string= (pel-elpa-package-name-for "other-pkg-2.3rc1")          "other-pkg"))
   ;; Package names containing + or _ characters
   (should (string= (pel-elpa-package-name-for "c++-mode-1.0")              "c++-mode"))
+
+  (should (string= (pel-elpa-package-name-for "my_pkg-1.0")                "my_pkg"))
+  ;; Hyphenated pre-release suffix
+  (should (string= (pel-elpa-package-name-for "demo-1.0-pre")              "demo"))
+
   ;; Non-package directory names must return nil
   (should (null (pel-elpa-package-name-for "archives")))
   (should (null (pel-elpa-package-name-for "gnupg")))

--- a/test/pel-package-test.el
+++ b/test/pel-package-test.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Wednesday, March 24 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-16 15:58:40 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-25 22:51:01 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -274,6 +274,61 @@
 
 
 
+(ert-deftest ert-test-pel-pkgs-sorted-by-version/semver ()
+  "Test `pel-pkgs-sorted-by-version' with classic semantic version numbers.
+This verifies that entries using dotted semver strings (e.g. \"1.2.3\") are
+sorted correctly, complementing the MELPA-timestamp coverage in
+`ert-test-pel-pkgs-sorted-by-version'."
+  (let ((pkglist '("/some/dir/elpa/seq-2.23"
+                   "/some/dir/elpa/seq-0.7"
+                   "/some/dir/elpa/seq-1.4"))
+        (sorted  '("/some/dir/elpa/seq-0.7"
+                   "/some/dir/elpa/seq-1.4"
+                   "/some/dir/elpa/seq-2.23")))
+    (should (equal (pel-pkgs-sorted-by-version pkglist) sorted)))
+  ;; Single entry: must return a one-element list unchanged.
+  (should (equal (pel-pkgs-sorted-by-version '("/some/dir/elpa/seq-2.23"))
+                 '("/some/dir/elpa/seq-2.23"))))
+
+
+(ert-deftest ert-test-pel-pkgs-sorted-by-version/alphanumeric-prerelease ()
+  "Test `pel-pkgs-sorted-by-version' with alphanumeric pre-release suffixes.
+
+Emacs `version<' recognises the keywords pre, alpha, beta, rc and snapshot as
+pre-release markers (see `version-to-list'), so these test cases use only those
+known keywords.  The expected ordering is:
+
+  alpha < beta < pre/rc < (no suffix / release)
+
+which means:
+  0.9.1pre < 0.9.2pre < 1.0.0
+  1.0.0alpha1 < 1.0.0beta2 < 1.0.0"
+  ;; Case 1: two pre-release variants and a release, full path form.
+  (let ((pkglist '("/some/dir/elpa/cask-1.0.0"
+                   "/some/dir/elpa/cask-0.9.2pre"
+                   "/some/dir/elpa/cask-0.9.1pre"))
+        (sorted  '("/some/dir/elpa/cask-0.9.1pre"
+                   "/some/dir/elpa/cask-0.9.2pre"
+                   "/some/dir/elpa/cask-1.0.0")))
+    (should (equal (pel-pkgs-sorted-by-version pkglist) sorted)))
+  ;; Case 2: alpha < beta < release.
+  (let ((pkglist '("/some/dir/elpa/mypkg-1.0.0beta2"
+                   "/some/dir/elpa/mypkg-1.0.0"
+                   "/some/dir/elpa/mypkg-1.0.0alpha1"))
+        (sorted  '("/some/dir/elpa/mypkg-1.0.0alpha1"
+                   "/some/dir/elpa/mypkg-1.0.0beta2"
+                   "/some/dir/elpa/mypkg-1.0.0")))
+    (should (equal (pel-pkgs-sorted-by-version pkglist) sorted)))
+  ;; Edge case: single pre-release entry must be returned as-is.
+  (should (equal (pel-pkgs-sorted-by-version '("/some/dir/elpa/cask-0.9.1pre"))
+                 '("/some/dir/elpa/cask-0.9.1pre")))
+  ;; Edge case: entries without a recognisable version must not crash;
+  ;; the list length is preserved.
+  (should (= (length (pel-pkgs-sorted-by-version
+                      '("/some/dir/elpa/archives"
+                        "/some/dir/elpa/cask-0.9.1pre"
+                        "/some/dir/elpa/cask-1.0.0")))
+             3)))
 
 ;;; --------------------------------------------------------------------------
 (provide 'pel-package-test)


### PR DESCRIPTION
* `pel-elpa-package-name-for` is now able to handle package name like "cask-0.9.1pre"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package-name parsing to correctly recognize version suffixes with alphanumeric parts (e.g., "0.9.1pre", "1.0alpha", "2.3rc1", "0.9.1-pre").

* **Refactor**
  * Standardized package name/version patterns and centralised parsing logic to improve discovery and sorting of packages.

* **Tests**
  * Added unit tests for name extraction from timestamped/versioned directories and for sorting with semver and alphanumeric prerelease variants.

* **Chores**
  * Updated file timestamps and comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->