### PR TITLE
Allow switching startup mode in GUI Emacs using quickstart.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ test/elisp-example-with-defun-in-strings.el
 test/pel-filedir-tests.el
 test/data/*
 
+# PEL build tag
+build/.check-init-stamp
+build/.compile-user-init-stamp
+
 # PEL test tag
 pel-ran-tests.tag
 test/*.test-passed

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-2026 by Pierre Rouleau
 
 # Author: Pierre Rouleau <prouleau001@gmail.com>
-# Last Modified Time-stamp: <2026-05-26 07:48:47 EDT, updated by Pierre Rouleau>
+# Last Modified Time-stamp: <2026-05-26 08:08:08 EDT, updated by Pierre Rouleau>
 # Keywords: packaging, build-control
 
 # This file is part of the PEL package
@@ -756,7 +756,7 @@ check-user-init-files:
 	          -l "build/check-init-versions-for-pel.el"
 else
 check-user-init-files:
-	`@printf` "CI build detected (GITHUB_WORKSPACE set): skipping user init file version check.\n"
+	@printf "CI build detected (GITHUB_WORKSPACE set): skipping user init file version check.\n"
 endif
 
 # -----------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-2026 by Pierre Rouleau
 
 # Author: Pierre Rouleau <prouleau001@gmail.com>
-# Last Modified Time-stamp: <2026-05-26 08:08:08 EDT, updated by Pierre Rouleau>
+# Last Modified Time-stamp: <2026-05-26 09:52:05 EDT, updated by Pierre Rouleau>
 # Keywords: packaging, build-control
 
 # This file is part of the PEL package
@@ -611,6 +611,34 @@ PEL_TAR_FILE := pel-$(PEL_VERSION).tar
 BIN_EL_FILES  := bin/pel-lint.el
 BIN_ELC_FILES := $(subst .el,.elc,$(BIN_EL_FILES))
 
+# ---------------------------------------------------------------------------
+# Byte-compile the user's init.el and early-init.el after they have been
+# validated and after PEL itself has been byte-compiled.
+#
+# WARNING: if you edit ~/.emacs.d/init.el or ~/.emacs.d/early-init.el
+#          manually, run  make compile-user-init  to refresh the .elc files.
+#          A stale .elc is harder to debug than a non-compiled init file.
+#
+ifeq ($(GITHUB_WORKSPACE),)
+build/.compile-user-init-stamp: build/.check-init-stamp pel.elc
+	@printf "Byte-compiling user init.el ...\n"
+	@$(EMACS) --batch -Q \
+	          --eval "(add-to-list 'load-path default-directory)" \
+	          -f batch-byte-compile \
+	          "$(PEL_EMACS_DIR)/init.el"
+	@if [ -f "$(PEL_EMACS_DIR)/early-init.el" ]; then \
+	    printf "Byte-compiling user early-init.el ...\n"; \
+	    $(EMACS) --batch -Q \
+	            -f batch-byte-compile \
+	            "$(PEL_EMACS_DIR)/early-init.el"; \
+	fi
+	@touch $@
+else
+build/.compile-user-init-stamp: build/.check-init-stamp pel.elc
+	@printf "CI build: skipping user init.el byte-compilation.\n"
+	@touch $@
+endif
+
 # -----------------------------------------------------------------------------
 # First rule, allows 'make' command to build everything that needs updating
 
@@ -621,7 +649,8 @@ BIN_ELC_FILES := $(subst .el,.elc,$(BIN_EL_FILES))
 #   as soon as its dependencies have been compiled.
 # - Compile pel_keys.el and pel.el at the end.
 
-all: check-user-init-files pel-top $(ALL_TEST_PASSED) pel_keys.elc pel.elc
+all: build/.check-init-stamp pel-top $(ALL_TEST_PASSED) pel_keys.elc pel.elc \
+     build/.compile-user-init-stamp
 
 pel-top: $(ALL_TEST_PASSED) $(ELC_FILES)
 
@@ -630,11 +659,12 @@ pel-top: $(ALL_TEST_PASSED) $(ELC_FILES)
 #   PEL files hold the logic to install external package and does not
 #   need any other tool to help for external package installation.
 
-first-build: $(ELC_FILES)
+first-build: build/.check-init-stamp $(ELC_FILES)
 
 # Target compile-only:
 # - Compile all .el files (including pel_keys.el and pel.el, done at the end).
-compile-only: check-user-init-files $(ELC_FILES) pel_keys.elc pel.elc
+compile-only: build/.check-init-stamp $(ELC_FILES) pel_keys.elc pel.elc \
+              build/.compile-user-init-stamp
 
 # -----------------------------------------------------------------------------
 # Self-desciptive rule: make help prints the info.
@@ -666,6 +696,7 @@ help:
 	@printf "                         compile all files except pel_keys.el and pel.el.\n"
 	@printf "                         No external file or package gets loaded.\n"
 	@printf "                         No tests are executed.\n"
+	@printf " * make check-init    - Check validity of user init.el and early-init.el\n"
 	@printf " * make test          - Run the regression tests.\n"
 	@printf " * make clean         - Remove $(PELPA_DIR),  all output files, all test tag files,\n"
 	@printf "                        and remove $(PEL_TAR_FILE)\n"
@@ -733,8 +764,8 @@ check-elc-files:
 	@echo ELC_FILES = "( $(ELC_FILES) )"
 
 # ---------------------------------------------------------------------------
-# Target check-user-init-files
-# ----------------------------
+# Ensure validity of user init/early-ini files
+# --------------------------------------------
 # Before any byte or native compilation, verify that the user's
 # ~/.emacs.d/init.el and (when present) ~/.emacs.d/early-init.el carry the
 # version numbers expected by this release of PEL.  An incompatible init file
@@ -746,18 +777,38 @@ check-elc-files:
 # Skipped automatically in GitHub CI (GITHUB_WORKSPACE is set) because CI
 # uses ci/init.el, which has its own separate compatibility guarantee.
 #
-.PHONY: check-user-init-files
+# Non-phony stamp target for the user init-file version check.
+# The check runs (at most once) whenever the checker script or the PEL template
+# files change.  All compilation and test targets depend on this file, so GNU Make
+# guarantees the check completes before any parallel job that depends on it.
+#
+# NOTE: changes to the *user's* ~/.emacs.d/init.el or early-init.el are outside
+#       the repository and therefore do not automatically invalidate this stamp.
+#       Run  make check-init  to force a fresh check after updating
+#       those files manually.
 
 ifeq ($(GITHUB_WORKSPACE),)
-check-user-init-files:
+build/.check-init-stamp: build/check-init-versions-for-pel.el \
+                          example/init/early-init.el \
+                          example/init/init.el
 	@$(EMACS) --batch -Q \
 	          --eval "(setenv \"PEL_EXAMPLE_DIR\"  \"example/init\")" \
 	          --eval "(setenv \"PEL_USER_EMACS_D\" (expand-file-name \"$(PEL_EMACS_DIR)\"))" \
 	          -l "build/check-init-versions-for-pel.el"
+	@touch $@
 else
-check-user-init-files:
+build/.check-init-stamp: build/check-init-versions-for-pel.el \
+                          example/init/early-init.el \
+                          example/init/init.el
 	@printf "CI build detected (GITHUB_WORKSPACE set): skipping user init file version check.\n"
+	@touch $@
 endif
+
+# Convenience alias: force a fresh check regardless of stamp age.
+.PHONY: check-init
+check-init:
+	`@rm` -f build/.check-init-stamp
+	$(MAKE) build/.check-init-stamp
 
 # -----------------------------------------------------------------------------
 # Creating the target directories when they don't exist.
@@ -1121,10 +1172,10 @@ test/pel-%-test.el.test-passed: test/pel-%-test.el $(ERT_TEST_DEP)
 
 .PHONY:	test clean-test
 
-test:	check-user-init-files $(ALL_TEST_PASSED)
+test:	build/.check-init-stamp $(ALL_TEST_PASSED)
 
 # The rm -f option prevents complaints from rm when the file is not present.
-clean-test:  check-user-init-files
+clean-test:
 	-rm -f test/*.test-passed
 
 # ----------------------------------------------------------------------------
@@ -1276,11 +1327,13 @@ clean-tar:
 clean-mypelpa:
 	-rm -rf $(PELPA_DIR)
 
-clean: check-user-init-files clean-tar clean-mypelpa clean-test
+clean: clean-tar clean-mypelpa clean-test
 	-rm *.elc
 	-rm -f $(BIN_ELC_FILES)
 	-rm -rf $(OUT_DIR)
 	-rm -rf $(TMP_DIR)
+	-rm -f build/.check-init-stamp
+	-rm -f build/.compile-user-init-stamp
 
 clean-build: clean all
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-2026 by Pierre Rouleau
 
 # Author: Pierre Rouleau <prouleau001@gmail.com>
-# Last Modified Time-stamp: <2026-05-26 14:13:08 EDT, updated by Pierre Rouleau>
+# Last Modified Time-stamp: <2026-05-26 14:38:29 EDT, updated by Pierre Rouleau>
 # Keywords: packaging, build-control
 
 # This file is part of the PEL package
@@ -612,8 +612,8 @@ BIN_EL_FILES  := bin/pel-lint.el
 BIN_ELC_FILES := $(subst .el,.elc,$(BIN_EL_FILES))
 
 # ---------------------------------------------------------------------------
-# Byte-compile the user's init.el and early-init.el after they have been
-# validated and after PEL itself has been byte-compiled.
+# Byte-compile the user's init.el and, when present, early-init.el after they
+# have been validated and after PEL itself has been byte-compiled.
 #
 # WARNING: if you edit ~/.emacs.d/init.el or ~/.emacs.d/early-init.el
 #          manually, run  make compile-init  to refresh the .elc files.
@@ -700,7 +700,7 @@ help:
 	@printf "Usage:\n"
 	@printf " * make               - Same as 'make all': build everything as needed.\n"
 	@printf " * make all           - Compile all files and run tests as soon as possible.\n"
-	@printf " * make compile-only  - Compile all Emacs Lisp user init and PEL files. Do not run tests.\n"
+	@printf " * make compile-only  - Compile all PEL Emacs Lisp and user init files. Do not run tests.\n"
 	@printf " * make pel           - Compile all files except pel.el. Do not run tests.\n"
 	@printf " * make first-build   - First build done on a virgin system:\n"
 	@printf "                         compile all files except pel_keys.el and pel.el.\n"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-2026 by Pierre Rouleau
 
 # Author: Pierre Rouleau <prouleau001@gmail.com>
-# Last Modified Time-stamp: <2026-05-25 18:12:24 EDT, updated by Pierre Rouleau>
+# Last Modified Time-stamp: <2026-05-26 07:48:47 EDT, updated by Pierre Rouleau>
 # Keywords: packaging, build-control
 
 # This file is part of the PEL package
@@ -621,7 +621,7 @@ BIN_ELC_FILES := $(subst .el,.elc,$(BIN_EL_FILES))
 #   as soon as its dependencies have been compiled.
 # - Compile pel_keys.el and pel.el at the end.
 
-all: pel-top $(ALL_TEST_PASSED) pel_keys.elc pel.elc
+all: check-user-init-files pel-top $(ALL_TEST_PASSED) pel_keys.elc pel.elc
 
 pel-top: $(ALL_TEST_PASSED) $(ELC_FILES)
 
@@ -634,7 +634,7 @@ first-build: $(ELC_FILES)
 
 # Target compile-only:
 # - Compile all .el files (including pel_keys.el and pel.el, done at the end).
-compile-only: $(ELC_FILES) pel_keys.elc pel.elc
+compile-only: check-user-init-files $(ELC_FILES) pel_keys.elc pel.elc
 
 # -----------------------------------------------------------------------------
 # Self-desciptive rule: make help prints the info.
@@ -643,6 +643,8 @@ compile-only: $(ELC_FILES) pel_keys.elc pel.elc
 help:
 	@printf "\nBuild Emacs PEL for use and distribution.\n"
 	@printf "\nStops on the first error (or compiler warning).\n"
+	@printf " Checks if user early-init.el and init.el are valid for PEL,\n"
+	@printf " and if they use the latest versions.\n"
 	@printf "\n"
 	@printf "Currently building PEL version $(PEL_VERSION).\n"
 	@printf "1) First byte-compile all Emacs Lisp files in required order.\n"
@@ -729,6 +731,33 @@ check-target:
 
 check-elc-files:
 	@echo ELC_FILES = "( $(ELC_FILES) )"
+
+# ---------------------------------------------------------------------------
+# Target check-user-init-files
+# ----------------------------
+# Before any byte or native compilation, verify that the user's
+# ~/.emacs.d/init.el and (when present) ~/.emacs.d/early-init.el carry the
+# version numbers expected by this release of PEL.  An incompatible init file
+# is caught early rather than producing a confusing build or runtime failure.
+#
+# The check is performed by build/check-init-versions-for-pel.el, a standalone Elisp
+# script that scans files as plain text (no package activation required).
+#
+# Skipped automatically in GitHub CI (GITHUB_WORKSPACE is set) because CI
+# uses ci/init.el, which has its own separate compatibility guarantee.
+#
+.PHONY: check-user-init-files
+
+ifeq ($(GITHUB_WORKSPACE),)
+check-user-init-files:
+	@$(EMACS) --batch -Q \
+	          --eval "(setenv \"PEL_EXAMPLE_DIR\"  \"example/init\")" \
+	          --eval "(setenv \"PEL_USER_EMACS_D\" (expand-file-name \"$(PEL_EMACS_DIR)\"))" \
+	          -l "build/check-init-versions-for-pel.el"
+else
+check-user-init-files:
+	`@printf` "CI build detected (GITHUB_WORKSPACE set): skipping user init file version check.\n"
+endif
 
 # -----------------------------------------------------------------------------
 # Creating the target directories when they don't exist.
@@ -1092,10 +1121,10 @@ test/pel-%-test.el.test-passed: test/pel-%-test.el $(ERT_TEST_DEP)
 
 .PHONY:	test clean-test
 
-test:	$(ALL_TEST_PASSED)
+test:	check-user-init-files $(ALL_TEST_PASSED)
 
 # The rm -f option prevents complaints from rm when the file is not present.
-clean-test:
+clean-test:  check-user-init-files
 	-rm -f test/*.test-passed
 
 # ----------------------------------------------------------------------------
@@ -1247,7 +1276,7 @@ clean-tar:
 clean-mypelpa:
 	-rm -rf $(PELPA_DIR)
 
-clean: clean-tar clean-mypelpa clean-test
+clean: check-user-init-files clean-tar clean-mypelpa clean-test
 	-rm *.elc
 	-rm -f $(BIN_ELC_FILES)
 	-rm -rf $(OUT_DIR)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-2026 by Pierre Rouleau
 
 # Author: Pierre Rouleau <prouleau001@gmail.com>
-# Last Modified Time-stamp: <2026-05-26 13:12:56 EDT, updated by Pierre Rouleau>
+# Last Modified Time-stamp: <2026-05-26 13:30:12 EDT, updated by Pierre Rouleau>
 # Keywords: packaging, build-control
 
 # This file is part of the PEL package
@@ -683,7 +683,7 @@ compile-only: build/.check-init-stamp $(ELC_FILES) pel_keys.elc pel.elc \
 help:
 	@printf "\nBuild Emacs PEL for use and distribution.\n"
 	@printf "\nStops on the first error (or compiler warning).\n"
-	@printf " Checks if user init.el, and when present, early-init.el are valid\n"
+	@printf " Checks if user init.el and, when present, early-init.el are valid\n"
 	@printf "  for PEL, and if they use the latest versions.\n"
 	@printf "\n"
 	@printf "Currently building PEL version $(PEL_VERSION).\n"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-2026 by Pierre Rouleau
 
 # Author: Pierre Rouleau <prouleau001@gmail.com>
-# Last Modified Time-stamp: <2026-05-26 10:36:35 EDT, updated by Pierre Rouleau>
+# Last Modified Time-stamp: <2026-05-26 11:42:32 EDT, updated by Pierre Rouleau>
 # Keywords: packaging, build-control
 
 # This file is part of the PEL package
@@ -616,12 +616,19 @@ BIN_ELC_FILES := $(subst .el,.elc,$(BIN_EL_FILES))
 # validated and after PEL itself has been byte-compiled.
 #
 # WARNING: if you edit ~/.emacs.d/init.el or ~/.emacs.d/early-init.el
-#          manually, run  make compile-user-init  to refresh the .elc files.
+#          manually, run  make compile-init  to refresh the .elc files.
 #          A stale .elc is harder to debug than a non-compiled init file.
 #          Also note that your ~/.emacs.d/init.el should not require any
 #          external packages, otherwise you will see warnings in the following
 #          byte compilation.
 #
+
+# Convenience: force recompilation regardless of stamp age.
+.PHONY: compile-init
+compile-init:
+	rm -f build/.compile-user-init-stamp
+	$(MAKE) build/.compile-user-init-stamp
+
 ifeq ($(GITHUB_WORKSPACE),)
 build/.compile-user-init-stamp: build/.check-init-stamp pel.elc
 	@printf "Byte-compiling user init.el ...\n"
@@ -699,9 +706,9 @@ help:
 	@printf "                         compile all files except pel_keys.el and pel.el.\n"
 	@printf "                         No external file or package gets loaded.\n"
 	@printf "                         No tests are executed.\n"
-	@printf " * make check-init    - Check validity of user init.el and, if present\n"
-	@printf "                         and early-init.el.\n"
+	@printf " * make check-init    - Check validity of user init.el and early-init.el if present\n"
 	@printf "                         Deletes the stamp to force a fresh check.\n"
+	@printf " * make compile-init  - Force recompilation of init files.\n"
 	@printf " * make test          - Run the regression tests.\n"
 	@printf " * make clean         - Remove $(PELPA_DIR),  all output files, all test tag files,\n"
 	@printf "                        and remove $(PEL_TAR_FILE)\n"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-2026 by Pierre Rouleau
 
 # Author: Pierre Rouleau <prouleau001@gmail.com>
-# Last Modified Time-stamp: <2026-05-26 11:42:32 EDT, updated by Pierre Rouleau>
+# Last Modified Time-stamp: <2026-05-26 12:12:22 EDT, updated by Pierre Rouleau>
 # Keywords: packaging, build-control
 
 # This file is part of the PEL package
@@ -626,7 +626,7 @@ BIN_ELC_FILES := $(subst .el,.elc,$(BIN_EL_FILES))
 # Convenience: force recompilation regardless of stamp age.
 .PHONY: compile-init
 compile-init:
-	rm -f build/.compile-user-init-stamp
+	@rm -f build/.compile-user-init-stamp
 	$(MAKE) build/.compile-user-init-stamp
 
 ifeq ($(GITHUB_WORKSPACE),)
@@ -683,8 +683,8 @@ compile-only: build/.check-init-stamp $(ELC_FILES) pel_keys.elc pel.elc \
 help:
 	@printf "\nBuild Emacs PEL for use and distribution.\n"
 	@printf "\nStops on the first error (or compiler warning).\n"
-	@printf " Checks if user early-init.el and init.el are valid for PEL,\n"
-	@printf " and if they use the latest versions.\n"
+	@printf " Checks if user init.el, and when present early-init.el are valid\n"
+	@printf "  for PEL, and if they use the latest versions.\n"
 	@printf "\n"
 	@printf "Currently building PEL version $(PEL_VERSION).\n"
 	@printf "1) First byte-compile all Emacs Lisp files in required order.\n"
@@ -706,7 +706,7 @@ help:
 	@printf "                         compile all files except pel_keys.el and pel.el.\n"
 	@printf "                         No external file or package gets loaded.\n"
 	@printf "                         No tests are executed.\n"
-	@printf " * make check-init    - Check validity of user init.el and early-init.el if present\n"
+	@printf " * make check-init    - Check validity of user init.el and early-init.el, if present.\n"
 	@printf "                         Deletes the stamp to force a fresh check.\n"
 	@printf " * make compile-init  - Force recompilation of init files.\n"
 	@printf " * make test          - Run the regression tests.\n"
@@ -776,8 +776,8 @@ check-elc-files:
 	@echo ELC_FILES = "( $(ELC_FILES) )"
 
 # ---------------------------------------------------------------------------
-# Ensure validity of user init/early-ini files
-# --------------------------------------------
+# Ensure validity of user init/early-init files
+# ---------------------------------------------
 # Before any byte or native compilation, verify that the user's
 # ~/.emacs.d/init.el and (when present) ~/.emacs.d/early-init.el carry the
 # version numbers expected by this release of PEL.  An incompatible init file

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-2026 by Pierre Rouleau
 
 # Author: Pierre Rouleau <prouleau001@gmail.com>
-# Last Modified Time-stamp: <2026-05-26 09:52:05 EDT, updated by Pierre Rouleau>
+# Last Modified Time-stamp: <2026-05-26 10:36:35 EDT, updated by Pierre Rouleau>
 # Keywords: packaging, build-control
 
 # This file is part of the PEL package
@@ -618,6 +618,9 @@ BIN_ELC_FILES := $(subst .el,.elc,$(BIN_EL_FILES))
 # WARNING: if you edit ~/.emacs.d/init.el or ~/.emacs.d/early-init.el
 #          manually, run  make compile-user-init  to refresh the .elc files.
 #          A stale .elc is harder to debug than a non-compiled init file.
+#          Also note that your ~/.emacs.d/init.el should not require any
+#          external packages, otherwise you will see warnings in the following
+#          byte compilation.
 #
 ifeq ($(GITHUB_WORKSPACE),)
 build/.compile-user-init-stamp: build/.check-init-stamp pel.elc
@@ -652,7 +655,7 @@ endif
 all: build/.check-init-stamp pel-top $(ALL_TEST_PASSED) pel_keys.elc pel.elc \
      build/.compile-user-init-stamp
 
-pel-top: $(ALL_TEST_PASSED) $(ELC_FILES)
+pel-top: build/.check-init-stamp $(ALL_TEST_PASSED) $(ELC_FILES)
 
 # Target first-build:
 # - Compile all .el files except pel_keys.el and pel.el
@@ -696,7 +699,9 @@ help:
 	@printf "                         compile all files except pel_keys.el and pel.el.\n"
 	@printf "                         No external file or package gets loaded.\n"
 	@printf "                         No tests are executed.\n"
-	@printf " * make check-init    - Check validity of user init.el and early-init.el\n"
+	@printf " * make check-init    - Check validity of user init.el and, if present\n"
+	@printf "                         and early-init.el.\n"
+	@printf "                         Deletes the stamp to force a fresh check.\n"
 	@printf " * make test          - Run the regression tests.\n"
 	@printf " * make clean         - Remove $(PELPA_DIR),  all output files, all test tag files,\n"
 	@printf "                        and remove $(PEL_TAR_FILE)\n"
@@ -807,7 +812,7 @@ endif
 # Convenience alias: force a fresh check regardless of stamp age.
 .PHONY: check-init
 check-init:
-	`@rm` -f build/.check-init-stamp
+	@rm -f build/.check-init-stamp
 	$(MAKE) build/.check-init-stamp
 
 # -----------------------------------------------------------------------------
@@ -1121,7 +1126,6 @@ else
 	$(EMACS) -Q --batch -L . --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile $<
 endif
 
-.PHONY:	pel
 # Target to byte-compile all Emacs Lisp files inside one Emacs Session.
 # Compile all without any init configuration.
 # Compile pel_keys.el last, *with* init.el so it can find the external packages.
@@ -1134,8 +1138,9 @@ endif
 # - When all EL_FILES are byte compiled and the ERT tests have run and succeeded, then:
 #   - byte compile pel_keys.el
 #   - byte compile pel.el
+.PHONY:	pel
 
-pel: $(ELC_FILES) pel_keys.elc
+pel: build/.check-init-stamp $(ELC_FILES) pel_keys.elc
 
 pel.elc: pel.el pel_keys.elc
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-2026 by Pierre Rouleau
 
 # Author: Pierre Rouleau <prouleau001@gmail.com>
-# Last Modified Time-stamp: <2026-05-26 13:51:57 EDT, updated by Pierre Rouleau>
+# Last Modified Time-stamp: <2026-05-26 14:13:08 EDT, updated by Pierre Rouleau>
 # Keywords: packaging, build-control
 
 # This file is part of the PEL package
@@ -677,7 +677,7 @@ compile-only: build/.check-init-stamp $(ELC_FILES) pel_keys.elc pel.elc \
               build/.compile-user-init-stamp
 
 # -----------------------------------------------------------------------------
-# Self-desciptive rule: make help prints the info.
+# Self-descriptive rule: make help prints the info.
 
 .PHONY: help
 help:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-2026 by Pierre Rouleau
 
 # Author: Pierre Rouleau <prouleau001@gmail.com>
-# Last Modified Time-stamp: <2026-05-26 13:30:12 EDT, updated by Pierre Rouleau>
+# Last Modified Time-stamp: <2026-05-26 13:42:53 EDT, updated by Pierre Rouleau>
 # Keywords: packaging, build-control
 
 # This file is part of the PEL package
@@ -708,7 +708,8 @@ help:
 	@printf "                         No tests are executed.\n"
 	@printf " * make check-init    - Check validity of user init.el and, if present, early-init.el.\n"
 	@printf "                         Deletes the stamp to force a fresh check.\n"
-	@printf " * make compile-init  - Force recompilation of init files.\n"
+	@printf " * make compile-init  - Force byte-recompilation of user init.el and early-init.el.\n"
+	@printf "                        Run this after manually editing those files.\n"
 	@printf " * make test          - Run the regression tests.\n"
 	@printf " * make clean         - Remove $(PELPA_DIR),  all output files, all test tag files,\n"
 	@printf "                        and remove $(PEL_TAR_FILE)\n"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-2026 by Pierre Rouleau
 
 # Author: Pierre Rouleau <prouleau001@gmail.com>
-# Last Modified Time-stamp: <2026-05-26 12:12:22 EDT, updated by Pierre Rouleau>
+# Last Modified Time-stamp: <2026-05-26 13:12:56 EDT, updated by Pierre Rouleau>
 # Keywords: packaging, build-control
 
 # This file is part of the PEL package
@@ -683,7 +683,7 @@ compile-only: build/.check-init-stamp $(ELC_FILES) pel_keys.elc pel.elc \
 help:
 	@printf "\nBuild Emacs PEL for use and distribution.\n"
 	@printf "\nStops on the first error (or compiler warning).\n"
-	@printf " Checks if user init.el, and when present early-init.el are valid\n"
+	@printf " Checks if user init.el, and when present, early-init.el are valid\n"
 	@printf "  for PEL, and if they use the latest versions.\n"
 	@printf "\n"
 	@printf "Currently building PEL version $(PEL_VERSION).\n"
@@ -700,13 +700,13 @@ help:
 	@printf "Usage:\n"
 	@printf " * make               - Same as 'make all': build everything as needed.\n"
 	@printf " * make all           - Compile all files and run tests as soon as possible.\n"
-	@printf " * make compile-only  - Compile all Emacs Lisp files. Do not run tests.\n"
+	@printf " * make compile-only  - Compile all Emacs Lisp user init and PEL files. Do not run tests.\n"
 	@printf " * make pel           - Compile all files except pel.el. Do not run tests.\n"
 	@printf " * make first-build   - First build done on a virgin system:\n"
 	@printf "                         compile all files except pel_keys.el and pel.el.\n"
 	@printf "                         No external file or package gets loaded.\n"
 	@printf "                         No tests are executed.\n"
-	@printf " * make check-init    - Check validity of user init.el and early-init.el, if present.\n"
+	@printf " * make check-init    - Check validity of user init.el and, if present, early-init.el.\n"
 	@printf "                         Deletes the stamp to force a fresh check.\n"
 	@printf " * make compile-init  - Force recompilation of init files.\n"
 	@printf " * make test          - Run the regression tests.\n"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-2026 by Pierre Rouleau
 
 # Author: Pierre Rouleau <prouleau001@gmail.com>
-# Last Modified Time-stamp: <2026-05-26 13:42:53 EDT, updated by Pierre Rouleau>
+# Last Modified Time-stamp: <2026-05-26 13:51:57 EDT, updated by Pierre Rouleau>
 # Keywords: packaging, build-control
 
 # This file is part of the PEL package
@@ -708,7 +708,7 @@ help:
 	@printf "                         No tests are executed.\n"
 	@printf " * make check-init    - Check validity of user init.el and, if present, early-init.el.\n"
 	@printf "                         Deletes the stamp to force a fresh check.\n"
-	@printf " * make compile-init  - Force byte-recompilation of user init.el and early-init.el.\n"
+	@printf " * make compile-init  - Force byte-recompilation of user init.el and, when present, early-init.el.\n"
 	@printf "                        Run this after manually editing those files.\n"
 	@printf " * make test          - Run the regression tests.\n"
 	@printf " * make clean         - Remove $(PELPA_DIR),  all output files, all test tag files,\n"

--- a/NEWS
+++ b/NEWS
@@ -8,7 +8,7 @@ PEL -- Pragmatic Emacs Leverage --  NEWS         -*- org -*-
   It is important to use PEL compatible early-init.el and init.el to use PEL.
   Templates for those files are stored in the example/init directory and they are used for this verification.
   This protects users when an important change to these template files is published.
-- PEL Makefile byte-compiles user's init.el and early-init.el.
+- PEL Makefile byte-compiles user's init.el and early-init.el when present.
 - All PEL PDF files are now hosted on a GitHub Pages site.  The PDF files should now be rendered by all web browsers, not only Firefox.
   The original URL of the PDF files remain but the ones in the Pages site differ and all internal links use the Pages site URL.
 - *Breaking change: major overhaul* of configuration and logic for specialized file searching done by *pel-open-at-point* and the

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,10 @@
 PEL -- Pragmatic Emacs Leverage --  NEWS         -*- org -*-
 
 * New in Version 0.4.2 (under development):
-- PEL Makefile now checks the validity of the user's init.el and , when present, early-init.el before building PEL and reports issues.
+- You can now write your own extra Emacs initialization code inside your own Emacs Lisp file identified by the
+  PEL *pel-user-extra-code-feature* user-option.  PEL will load this file after loading itself.
+  You can extend PEL's capabilities this way.
+- PEL Makefile now checks the validity of the user's init.el and, when present, early-init.el before building PEL and reports issues.
   It is important to use PEL compatible early-init.el and init.el to use PEL.
   Templates for those files are stored in the example/init directory and they are used for this verification.
   This protects users when an important change to these template files is published.

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,10 @@
 PEL -- Pragmatic Emacs Leverage --  NEWS         -*- org -*-
 
 * New in Version 0.4.2 (under development):
+- PEL Makefile now checks the validity of the user's early-init.el and init.el before building PEL and reports issues.
+  It is important to use PEL compatible early-init.el and init.el to use PEL.
+  Templates for those files are stored in the example/init directory and they are used for this verification.
+  This protects users when an important change to these template files is published.
 - All PEL PDF files are now hosted on a GitHub Pages site.  The PDF files should now be rendered by all web browsers, not only Firefox.
   The original URL of the PDF files remain but the ones in the Pages site differ and all internal links use the Pages site URL.
 - *Breaking change: major overhaul* of configuration and logic for specialized file searching done by *pel-open-at-point* and the

--- a/NEWS
+++ b/NEWS
@@ -1,10 +1,11 @@
 PEL -- Pragmatic Emacs Leverage --  NEWS         -*- org -*-
 
 * New in Version 0.4.2 (under development):
-- PEL Makefile now checks the validity of the user's early-init.el and init.el before building PEL and reports issues.
+- PEL Makefile now checks the validity of the user's init.el and , when present, early-init.el before building PEL and reports issues.
   It is important to use PEL compatible early-init.el and init.el to use PEL.
   Templates for those files are stored in the example/init directory and they are used for this verification.
   This protects users when an important change to these template files is published.
+- PEL Makefile byte-compiles user's init.el and early-init.el.
 - All PEL PDF files are now hosted on a GitHub Pages site.  The PDF files should now be rendered by all web browsers, not only Firefox.
   The original URL of the PDF files remain but the ones in the Pages site differ and all internal links use the Pages site URL.
 - *Breaking change: major overhaul* of configuration and logic for specialized file searching done by *pel-open-at-point* and the

--- a/NEWS
+++ b/NEWS
@@ -8,9 +8,9 @@ PEL -- Pragmatic Emacs Leverage --  NEWS         -*- org -*-
   It is important to use PEL compatible early-init.el and init.el to use PEL.
   Templates for those files are stored in the example/init directory and they are used for this verification.
   This protects users when an important change to these template files is published.
-- PEL Makefile byte-compiles user's init.el and early-init.el when present.
 - All PEL PDF files are now hosted on a GitHub Pages site.  The PDF files should now be rendered by all web browsers, not only Firefox.
   The original URL of the PDF files remain but the ones in the Pages site differ and all internal links use the Pages site URL.
+- PEL Makefile byte-compiles user's init.el and, when present, early-init.el.
 - *Breaking change: major overhaul* of configuration and logic for specialized file searching done by *pel-open-at-point* and the
   pel-ffind functions.
   - All specialized file searching is now controlled by the concept of development *project* and no longer major mode specific as

--- a/bin/build-pel
+++ b/bin/build-pel
@@ -4,7 +4,7 @@
 # Purpose   : Build PEL quickly from scratch then run all tests and display stats.
 # Created   : Monday, May 11 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-11 13:44:46 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-26 12:21:10 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -25,5 +25,5 @@
 # ----
 #
 
-make clean && make -j compile-only && make lint && make && make stats
+make check-init && make clean && make -j compile-only && make lint && make && make stats
 # ----------------------------------------------------------------------------

--- a/bin/build-pel
+++ b/bin/build-pel
@@ -4,15 +4,18 @@
 # Purpose   : Build PEL quickly from scratch then run all tests and display stats.
 # Created   : Monday, May 11 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-26 12:21:10 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-26 14:41:31 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
 #
-# Build PEL Emacs Lisp code quickly, then check if there are any issues in the
-# key prefix logic between pel_keys.el and pel--keys-macros.el, then run all
-# unit test and complete by checking PEL stats.
-
+# Does the following:
+#
+# - Check validity of user's init.el and early-init.el files,
+# - build PEL Emacs Lisp code quickly (using concurrent Make build),
+# - check if there are any issues in the key prefix logic between pel_keys.el and pel--keys-macros.el,
+# - run all unit tests
+# - and complete by loading everything in an Emacs session then print PEL stats.
 
 # ----------------------------------------------------------------------------
 # Dependencies
@@ -25,5 +28,8 @@
 # ----
 #
 
+# Check user init and early-init right at the beginning to prevent cleaning
+# if the user's file should be updated.
+#
 make check-init && make clean && make -j compile-only && make lint && make && make stats
 # ----------------------------------------------------------------------------

--- a/build/check-init-versions-for-pel.el
+++ b/build/check-init-versions-for-pel.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, May 26 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-26 10:31:27 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-26 12:18:43 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -102,9 +102,9 @@ not readable or VARNAME is not found."
   ;; -- Check early-init.el (present only on Emacs >= 27)
   ;; Absence of the file is not an error: Emacs 26 users have no
   ;; early-init.el.
-  ;;  If PEL users using Emacs >= 27 do not have an early-init.el and they
-  ;;  try to activate quickstart mode PEL will detect that and can create the
-  ;;  file for the user.
+  ;; - If PEL users using Emacs >= 27 do not have an early-init.el and they
+  ;;   try to activate quickstart mode PEL will detect that and can create the
+  ;;   file for the user.
   (cond
    ;;
    ((and (file-exists-p user-early-init)

--- a/build/check-init-versions-for-pel.el
+++ b/build/check-init-versions-for-pel.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, May 26 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-26 07:36:08 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-26 08:07:44 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the CHECK package.
 ;; This file is not part of GNU Emacs.
@@ -29,7 +29,7 @@
 ;;             carry the version numbers expected by this PEL release.
 ;; Called by : The PEL Makefile target `check-user-init-files', before any
 ;;             byte or native compilation.
-;; Usage     : emacs --batch -Q -l build/check-init-versions.el
+;; Usage     : emacs --batch -Q -l build/check-init-versions-for-pel.el
 ;;             (the Makefile sets PEL_EXAMPLE_DIR and PEL_USER_EMACS_D via
 ;;             --eval "(setenv ...)" before loading this file.)
 ;; Notes     : - Does NOT load user or example files; scans them as text.
@@ -105,7 +105,14 @@ not readable or VARNAME is not found."
   ;;  If PEL users using Emacs >= 27 do not have an early-init.el and they
   ;;  try to activate quickstart mode PEL will detect that and can create the
   ;;  file for the user.
-  (when (file-readable-p user-early-init)
+  (cond
+   ;;
+   ((and (file-exists-p user-early-init)
+         (not (file-readable-p user-early-init)))
+    (push (format "Cannot read user early-init.el: %s" user-early-init)
+          errors))
+   ;;
+   ((file-readable-p user-early-init)
     (let ((expected (pel--check-init-extract-version example-early
                                                      "pel-early-init-file-version"))
           (actual   (pel--check-init-extract-version user-early-init
@@ -127,7 +134,7 @@ not readable or VARNAME is not found."
   Please update   : %s\n\
   Using template  : %s"
                       actual expected user-early-init example-early)
-              errors)))))
+              errors))))))
 
   ;; ── Report and exit ───────────────────────────────────────────────────────
   (if errors

--- a/build/check-init-versions-for-pel.el
+++ b/build/check-init-versions-for-pel.el
@@ -2,9 +2,9 @@
 
 ;; Created   : Tuesday, May 26 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-26 08:07:44 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-26 09:37:29 EDT, updated by Pierre Rouleau>
 
-;; This file is part of the CHECK package.
+;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
 
 ;; Copyright (C) 2026  Pierre Rouleau

--- a/build/check-init-versions-for-pel.el
+++ b/build/check-init-versions-for-pel.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, May 26 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-26 12:18:43 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-26 13:40:45 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -145,7 +145,7 @@ not readable or VARNAME is not found."
           (message "\n* %s" e))
         (message "\nResolve the above issue(s) before rebuilding PEL.
   Please compare your version of the file(s) with the versions stored
-  inside the example/init directory.\n")
+  inside %s.\n" example-dir)
         (kill-emacs 1))
     (message "PEL init file version check: OK.")))
 

--- a/build/check-init-versions-for-pel.el
+++ b/build/check-init-versions-for-pel.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, May 26 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-26 09:37:29 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-26 10:31:27 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -27,8 +27,8 @@
 ;;
 ;; Purpose   : Verify that the user's init.el and early-init.el (when present)
 ;;             carry the version numbers expected by this PEL release.
-;; Called by : The PEL Makefile target `check-user-init-files', before any
-;;             byte or native compilation.
+;; Called by : The PEL Makefile stamp target `build/.check-init-stamp' (run
+;;             via `make check-init'), before any byte or native compilation.
 ;; Usage     : emacs --batch -Q -l build/check-init-versions-for-pel.el
 ;;             (the Makefile sets PEL_EXAMPLE_DIR and PEL_USER_EMACS_D via
 ;;             --eval "(setenv ...)" before loading this file.)

--- a/build/check-init-versions-for-pel.el
+++ b/build/check-init-versions-for-pel.el
@@ -1,0 +1,148 @@
+;;; check-init-versions-for-pel.el --- PEL pre-build check of early-init and init files  -*- lexical-binding: t; -*-
+
+;; Created   : Tuesday, May 26 2026.
+;; Author    : Pierre Rouleau <prouleau001@gmail.com>
+;; Time-stamp: <2026-05-26 07:36:08 EDT, updated by Pierre Rouleau>
+
+;; This file is part of the CHECK package.
+;; This file is not part of GNU Emacs.
+
+;; Copyright (C) 2026  Pierre Rouleau
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; --------------------------------------------------------------------------
+;;; Commentary:
+;;
+;; Purpose   : Verify that the user's init.el and early-init.el (when present)
+;;             carry the version numbers expected by this PEL release.
+;; Called by : The PEL Makefile target `check-user-init-files', before any
+;;             byte or native compilation.
+;; Usage     : emacs --batch -Q -l build/check-init-versions.el
+;;             (the Makefile sets PEL_EXAMPLE_DIR and PEL_USER_EMACS_D via
+;;             --eval "(setenv ...)" before loading this file.)
+;; Notes     : - Does NOT load user or example files; scans them as text.
+;;             - Therefore requires no external packages.
+;;             - Reports all mismatches before exiting non-zero so the user
+;;               sees every problem at once.
+
+;;; --------------------------------------------------------------------------
+;;; Dependencies:
+;;
+;; None: use standard Emacs code.
+
+;;; --------------------------------------------------------------------------
+;;; Code:
+;;
+
+;;; ---------------------------------------------------------------------------
+;;; Helper
+
+(defun pel--check-init-extract-version (file varname)
+  "Return the string value of a (defconst VARNAME \"...\") form in FILE.
+Scans FILE as plain text without executing it.  Returns nil when FILE is
+not readable or VARNAME is not found."
+  (when (file-readable-p file)
+    (with-temp-buffer
+      (insert-file-contents file)
+      (goto-char (point-min))
+      (when (re-search-forward
+             (concat "(defconst\\s-+" (regexp-quote varname)
+                     "\\s-+\"\\([^\"]+\\)\"")
+             nil t)
+        (match-string 1)))))
+
+;;; ---------------------------------------------------------------------------
+;;; Main check
+
+(let* ((example-dir      (or (getenv "PEL_EXAMPLE_DIR")  "example/init"))
+       (user-emacs-d     (or (getenv "PEL_USER_EMACS_D")
+                             (expand-file-name "~/.emacs.d")))
+       (example-init     (expand-file-name "init.el"       example-dir))
+       (example-early    (expand-file-name "early-init.el" example-dir))
+       (user-init        (expand-file-name "init.el"       user-emacs-d))
+       (user-early-init  (expand-file-name "early-init.el" user-emacs-d))
+       (errors           nil))
+
+  ;; -- Check init.el
+  (if (not (file-readable-p user-init))
+      (push (format "Cannot read user init.el: %s" user-init) errors)
+    (let ((expected (pel--check-init-extract-version example-init "pel-init-file-version"))
+          (actual   (pel--check-init-extract-version user-init    "pel-init-file-version")))
+      (cond
+       ((null expected)
+        (push (format "Cannot determine expected pel-init-file-version from %s."
+                      example-init)
+              errors))
+       ((null actual)
+        (push (format "%s does not define `pel-init-file-version'.\n\
+  Update it from %s (expected version: \"%s\")."
+                      user-init example-init expected)
+              errors))
+       ((not (string= actual expected))
+        (push (format "init.el version mismatch:\n\
+  Your version    : \"%s\"\n\
+  Required version: \"%s\"\n\
+  Please update   : %s\n\
+  Using template  : %s"
+                      actual expected user-init example-init)
+              errors)))))
+
+  ;; -- Check early-init.el (present only on Emacs >= 27)
+  ;; Absence of the file is not an error: Emacs 26 users have no
+  ;; early-init.el.
+  ;;  If PEL users using Emacs >= 27 do not have an early-init.el and they
+  ;;  try to activate quickstart mode PEL will detect that and can create the
+  ;;  file for the user.
+  (when (file-readable-p user-early-init)
+    (let ((expected (pel--check-init-extract-version example-early
+                                                     "pel-early-init-file-version"))
+          (actual   (pel--check-init-extract-version user-early-init
+                                                     "pel-early-init-file-version")))
+      (cond
+       ((null expected)
+        (push (format "Cannot determine expected pel-early-init-file-version from %s."
+                      example-early)
+              errors))
+       ((null actual)
+        (push (format "%s does not define `pel-early-init-file-version'.\n\
+  Update it from %s (expected version: \"%s\")."
+                      user-early-init example-early expected)
+              errors))
+       ((not (string= actual expected))
+        (push (format "early-init.el version mismatch:\n\
+  Your version    : \"%s\"\n\
+  Required version: \"%s\"\n\
+  Please update   : %s\n\
+  Using template  : %s"
+                      actual expected user-early-init example-early)
+              errors)))))
+
+  ;; ── Report and exit ───────────────────────────────────────────────────────
+  (if errors
+      (progn
+        (message "\nPEL BUILD ERROR - Init file version check FAILED")
+        (message   "=================================================")
+        (dolist (e (nreverse errors))
+          (message "\n* %s" e))
+        (message "\nResolve the above issue(s) before rebuilding PEL.
+  Please compare your version of the file(s) with the versions stored
+  inside the example/init directory.\n")
+        (kill-emacs 1))
+    (message "PEL init file version check: OK.")))
+
+;;; --------------------------------------------------------------------------
+(provide 'check-init-versions-for-pel)
+
+;;; check-init-versions-for-pel.el ends here

--- a/example/init/early-init.el
+++ b/example/init/early-init.el
@@ -145,7 +145,8 @@ Has no effect when Emacs runs in terminal/TTY mode.")
 
 (defconst pel--ei-in-graphics-p
   (or
-   ;; For PEL controlled ec launched GUI where PEL_EMACS_IN_GRAPHICS envvar is defined.
+   ;; For PEL-controlled Emacs launched from a shell where PEL_EMACS_IN_GRAPHICS
+   ;; envvar is defined (as the PEL bin/ge script does).
    (string-equal (getenv "PEL_EMACS_IN_GRAPHICS") "1")
    ;; For pure GUI programs identified in `pel-emacs-gui-programs' user-option
    ;; then copied into `pel-early-init-emacs-gui-programs' above.

--- a/example/init/early-init.el
+++ b/example/init/early-init.el
@@ -19,7 +19,7 @@
 ;; `display-graphic-p' is not yet available when early-init.el is executed,
 ;; the code must resort to environment variables to detect if Emacs is running
 ;; in graphics mode or in terminal/TTY mode.  The code uses the presence of
-;; the "PEL_EMACS_IN_GRAPHICS" environment variable set to "1"" to identify
+;; the "PEL_EMACS_IN_GRAPHICS" environment variable set to "1" to identify
 ;; the graphics mode when Emacs is launched from a shell. For pure GUI Emacs
 ;; PEL uses the `pel-emacs-gui-programs' user-option; the absolute path of all
 ;; GUI Emacs commands available on this system.  This is copied into

--- a/example/init/early-init.el
+++ b/example/init/early-init.el
@@ -28,7 +28,7 @@
 ;; The code of this file does not load any Emacs Lisp file, it only uses what
 ;; is already available: the Emacs Lisp forms implemented in C and the ones
 ;; that are normally bundled in the Emacs dump.  This includes the files
-;; subrl.el.
+;; subr.el.
 ;;
 ;;
 ;; PEL Feature Control
@@ -64,7 +64,7 @@
 ;;     used.  If your shell does not have such environment variable, use
 ;;     something like "PEL_SHELL" and define it inside your shell
 ;;     initialization file (something like ~/.bashrc or ~/.bash_profile).
-;;     - Identified in early-init.el by `pel-emacs-gui-programs'.
+;;     - Identified in early-init.el by `pel-early-init-emacs-gui-programs'.
 ;;
 ;; - PEL fast startup:
 ;;   Whether PEL activates the fast startup mode.

--- a/example/init/early-init.el
+++ b/example/init/early-init.el
@@ -153,7 +153,7 @@ Has no effect when Emacs runs in terminal/TTY mode.")
         (member (expand-file-name invocation-name invocation-directory)
                 pel-early-init-emacs-gui-programs)))
   "Non-nil when early-init.el detects that Emacs is running in graphics mode.
-Uses the same heuristic as `pel-force-graphic-specific-custom-file-p'.")
+This value is used by `pel-force-graphic-specific-custom-file-p'.")
 
 (defconst pel-force-graphic-specific-custom-file-p
   (and pel-early-init-support-dual-environment-p

--- a/example/init/early-init.el
+++ b/example/init/early-init.el
@@ -17,12 +17,13 @@
 ;;
 ;; Since Emacs has not initialized its graphics support code and the function
 ;; `display-graphic-p' is not yet available when early-init.el is executed,
-;; the code must resort to environment variables to detect if Emacs is
-;; running in graphics mode or in terminal/TTY mode.  The code uses the
-;; presence of the "PEL_EMACS_IN_GRAPHICS" environment variable set to "1 to
-;; identify the graphics mode when Emacs is launched from a shell. For pure
-;; GUI Emacs PEL uses the `pel-emacs-gui-programs'; the absolute path of all
-;; GUI Emacs commands available on this system.
+;; the code must resort to environment variables to detect if Emacs is running
+;; in graphics mode or in terminal/TTY mode.  The code uses the presence of
+;; the "PEL_EMACS_IN_GRAPHICS" environment variable set to "1"" to identify
+;; the graphics mode when Emacs is launched from a shell. For pure GUI Emacs
+;; PEL uses the `pel-emacs-gui-programs' user-option; the absolute path of all
+;; GUI Emacs commands available on this system.  This is copied into
+;; `pel-early-init-emacs-gui-programs' constant.
 ;;
 ;; The code of this file does not load any Emacs Lisp file, it only uses what
 ;; is already available: the Emacs Lisp forms implemented in C and the ones
@@ -228,13 +229,13 @@ Uses the same heuristic as `pel-force-graphic-specific-custom-file-p'.")
 ;; sets it with `(unless pel-package-user-dir-original ...)'; that guard
 ;; makes the init.el assignment a no-op when this early-init code has
 ;; already saved the value.
-(when (boundp 'package-user-dir)
-  (defvar pel-package-user-dir-original nil
-    "Original `package-user-dir' captured at early-init time, before
-any PEL advice overwrites it for graphics/quickstart mode.
-Set by early-init.el; used by `pel-setup-normal' and `pel-setup-fast'
-to locate the elpa symlink regardless of quickstart and graphics mode.")
-  (setq pel-package-user-dir-original package-user-dir))
+
+(defvar pel-package-user-dir-original
+  (if (boundp 'package-user-dir)
+      package-user-dir
+    (expand-file-name "elpa" user-emacs-directory))
+  "Original `package-user-dir' captured at early-init time, before
+any PEL advice overwrites it for graphics/quickstart mode.")
 
 ;; ---------------------------------------------------------------------------
 ;; Disable UI Elements Early (Graphics Mode Only)
@@ -267,11 +268,10 @@ to locate the elpa symlink regardless of quickstart and graphics mode.")
 ;; ensure that:
 ;; - `package-user-dir' is adjusted to use the -graphics directory
 ;;   so that `load-path' gets packages from the -graphics directory.
-;; -
-;; package quickstart activation uses the graphics-specific files.
+;; - package quickstart activation uses the graphics-specific files.
 
 (defun pel--graphic-file-name (fname)
-  "Appends \"-graphics\" to the end of a .el, .elc or extension less FNAME."
+  "Appends \"-graphics\" to the end of a .el, .elc or extension-less FNAME."
   ;; use only functions implemented in C
   (let ((ext (substring fname -3)))
     (cond

--- a/example/init/early-init.el
+++ b/example/init/early-init.el
@@ -139,7 +139,7 @@ Has no effect when Emacs runs in terminal/TTY mode.")
 ;; The code below this line does not require editing.
 ;; ==================================================
 
-(defconst pel-early-init-file-version "0.4"
+(defconst pel-early-init-file-version "0.5"
   "Version of PEL early-init.el. Verified by pel-setup logic. Do NOT change.")
 
 (defconst pel--ei-in-graphics-p
@@ -216,6 +216,27 @@ Uses the same heuristic as `pel-force-graphic-specific-custom-file-p'.")
                     pel--startup-file-name-handler-alist))))
 
 ;; ---------------------------------------------------------------------------
+;; Capture original package-user-dir
+;; ==================================
+;; Save `package-user-dir' here, in early-init.el, BEFORE any advice can
+;; overwrite it.  `pel--ei-package-activate-all' (below) permanently
+;; overwrites `package-user-dir' to the -graphics variant when package
+;; quickstart is active in graphics mode.  By the time init.el runs, the
+;; original value is gone, so it must be saved now.
+;;
+;; `init.el' declares `pel-package-user-dir-original' with defvar and also
+;; sets it with `(unless pel-package-user-dir-original ...)'; that guard
+;; makes the init.el assignment a no-op when this early-init code has
+;; already saved the value.
+(when (boundp 'package-user-dir)
+  (defvar pel-package-user-dir-original nil
+    "Original `package-user-dir' captured at early-init time, before
+any PEL advice overwrites it for graphics/quickstart mode.
+Set by early-init.el; used by `pel-setup-normal' and `pel-setup-fast'
+to locate the elpa symlink regardless of quickstart and graphics mode.")
+  (setq pel-package-user-dir-original package-user-dir))
+
+;; ---------------------------------------------------------------------------
 ;; Disable UI Elements Early (Graphics Mode Only)
 ;; ===============================================
 ;; Tool bars, menu bars, and scroll bars are initialised by the C layer very
@@ -239,6 +260,15 @@ Uses the same heuristic as `pel-force-graphic-specific-custom-file-p'.")
   (setq frame-inhibit-implied-resize t))
 
 ;; ---------------------------------------------------------------------------
+;; Adjust file names for GUI Emacs
+;; ===============================
+;; If Emacs is running in Graphics mode with dual environment (independent
+;; customization and Elpa packages for terminal/TTY and graphics mode), then
+;; ensure that:
+;; - `package-user-dir' is adjusted to use the -graphics directory
+;;   so that `load-path' gets packages from the -graphics directory.
+;; -
+;; package quickstart activation uses the graphics-specific files.
 
 (defun pel--graphic-file-name (fname)
   "Appends \"-graphics\" to the end of a .el, .elc or extension less FNAME."
@@ -250,13 +280,6 @@ Uses the same heuristic as `pel-force-graphic-specific-custom-file-p'.")
      ((string-equal ext "elc") (concat (substring fname 0 -4) "-graphics.elc"))
      (t (concat fname "-graphics")))))
 
-;; If Emacs is running in Graphics mode with dual environment (independent
-;; customization and Elpa packages for terminal/TTY and graphics mode), then
-;; ensure that:
-;; - `package-user-dir' is adjusted to use the -graphics directory
-;;   so that `load-path' gets packages from the -graphics directory.
-;; -
-;; package quickstart activation uses the graphics-specific files.
 
 (when pel-force-graphic-specific-custom-file-p
 

--- a/example/init/early-init.el
+++ b/example/init/early-init.el
@@ -21,13 +21,13 @@
 ;; in graphics mode or in terminal/TTY mode.  The code uses the presence of
 ;; the "PEL_EMACS_IN_GRAPHICS" environment variable set to "1" to identify
 ;; the graphics mode when Emacs is launched from a shell. For pure GUI Emacs
-;; PEL uses the `pel-emacs-gui-programs' user-option; the absolute path of all
+;; PEL uses the `pel-emacs-gui-programs' user-option; the absolute paths of all
 ;; GUI Emacs commands available on this system.  This is copied into
 ;; `pel-early-init-emacs-gui-programs' constant.
 ;;
 ;; The code of this file does not load any Emacs Lisp file, it only uses what
 ;; is already available: the Emacs Lisp forms implemented in C and the ones
-;; that are normally bundled in the Emacs dump.  This includes the files
+;; that are normally bundled in the Emacs dump.  This includes the file
 ;; subr.el.
 ;;
 ;;

--- a/example/init/init.el
+++ b/example/init/init.el
@@ -126,7 +126,7 @@ the PEL directory structure on first invocation.")
 ;; directories have different extensions (in the context of this function
 ;; calls).
 (defun pel--graphic-file-name (fname)
-  "Appends \"-graphics\" to the end of a .el, .elc or extension less FNAME.
+  "Appends \"-graphics\" to the end of a .el, .elc or extension-less FNAME.
 Also expands to the file true name, replacing symlinks by what they point to."
   ;; use only functions implemented in C or elisp available early
   (let ((ext (substring fname -3)))

--- a/example/init/init.el
+++ b/example/init/init.el
@@ -102,7 +102,7 @@
   "Non-nil when PEL runs in fast startup mode, nil otherwise.")
 
 (defvar pel-package-user-dir-original nil
-  "When set, it is the dirpath of the `package-user-dir' symlink.
+  "The value of `package-user-dir' as captured before PEL overwrites it.
 
 The function `pel--init-package-support' stores the original
 value of dirpath here and updates the value of `package-user-dir'

--- a/example/init/init.el
+++ b/example/init/init.el
@@ -104,18 +104,15 @@
 (defvar pel-package-user-dir-original nil
   "The value of `package-user-dir' as captured before PEL overwrites it.
 
-The function `pel--init-package-support' stores the original
-value of dirpath here and updates the value of `package-user-dir'
-to control the format of the entries placed inside the
-`load-path'.
+Set by `early-init.el' at load time (preferred path), or by
+`pel--init-package-support' in `init.el' as a fallback when no
+`early-init.el' is present.
 
 PEL logic transforms `package-user-dir' to make it point to the
-elpa-complete or elpa-reduced directory (or the graphics
-equivalent in dual environment mode).  Having access to the
-original value will allow `pel-setup-fast' to create the symlink
-the very first time it is called when a user transforms its
-original Emacs directory into a directory that supports PEL
-startup mode management.")
+elpa-complete or elpa-reduced directory (or the graphics equivalent
+in dual environment mode).  Having access to the original value lets
+`pel-setup-fast' and `pel-setup-normal' correctly establish or remove
+the PEL directory structure on first invocation.")
 
 
 ;; Section 1 : Utility function definition
@@ -229,11 +226,11 @@ Also expands to the file true name, replacing symlinks by what they point to."
     ;; sets the `package-user-dir' dynamic value (not the user-option value we
     ;; see inside this function) to a true directory name, following all
     ;; symbolic links to their target, before package functions like
-    ;; `package-initialize' is called. This that `load-path' entries are true
-    ;; directory names, fully expanded (to symlink target if any symlink is
-    ;; used) to ensure continued validity of a process `load-path' even if the
-    ;; "~/.emacs.d/elpa" is a symlink and its target is changed by another
-    ;; process.
+    ;; `package-initialize' is called.  This ensures that `load-path' entries
+    ;; are true directory names, fully expanded (to symlink target if any
+    ;; symlink is used) to ensure continued validity of a process `load-path'
+    ;; even if the "~/.emacs.d/elpa" is a symlink and its target is changed by
+    ;; another process.
 
     (if (< emacs-major-version 27)
         ;; Emacs prior to 27

--- a/pel--options.el
+++ b/pel--options.el
@@ -635,6 +635,23 @@ the standard Emacs key bindings as well as PEL's specific key bindings."
   "PEL Emacs basic configuration."
   :group 'pel)
 
+(defcustom pel-user-extra-code-feature nil
+  "Optional user-specific feature name.
+
+Identify the feature provided by your own Emacs extra initialization
+file here. PEL will load this feature after completing loading of pel_keys
+when all PEL features are available.
+
+Enter the symbol corresponding to the (provide \\='your-extra-init)
+statement at the end of your file that provides this extra
+initialization.
+
+Store your extra init .el file inside your ~/.emacs.d to prevent PEL
+from attempting to manage it and minimize the number of directories in
+Emacs load-path."
+  :group 'pel-base-emacs
+  :type 'symbol)
+
 (defcustom pel-major-modes-with-no-indentation '(dired-mode
                                                  help-mode
                                                  ibuffer-mode

--- a/pel--options.el
+++ b/pel--options.el
@@ -656,7 +656,7 @@ CAUTION: don't forget to do the following:
   `pel-cleanup' command.
 - Byte compile your files to ensure they will load cleanly and quickly.
   You can use the bin/el-byte-compile script to do that from the command
-  line or byte compile it with by typing \\[pel-byte-compile-file-and-load]
+  line or byte compile it by typing \\[pel-byte-compile-file-and-load]
   from within Emacs."
   :group 'pel-base-emacs
   :type 'symbol)

--- a/pel--options.el
+++ b/pel--options.el
@@ -646,9 +646,18 @@ Enter the symbol corresponding to the (provide \\='your-extra-init)
 statement at the end of your file that provides this extra
 initialization.
 
-Store your extra init .el file inside your ~/.emacs.d to prevent PEL
-from attempting to manage it and minimize the number of directories in
-Emacs load-path."
+CAUTION: don't forget to do the following:
+
+- Store your extra init .el file and any other of your elisp files it
+  requires inside your ~/.emacs.d/utils directory to prevent adding
+  another entry to Emacs `load-path'.
+- Identify your files inside `pel-utils-packages-to-keep' to prevent PEL
+  from attempting to erase your files during the execution of the
+  `pel-cleanup' command.
+- Byte compile your files to ensure they will load cleanly and quickly.
+  You can use the bin/el-byte-compile script to do that from the command
+  line or byte compile it with by typing \\[pel-byte-compile-file-and-load]
+  from within Emacs."
   :group 'pel-base-emacs
   :type 'symbol)
 

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-26 10:15:58 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-26 10:30:23 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -193,15 +193,13 @@ Return nil if all is OK."
  - `pel-package-user-dir-original' is not bound.
    It should be set to remember `package-user-dir'."))
      ;;
-     ((and (boundp 'pel-package-user-dir-original)
-           (not (stringp pel-package-user-dir-original)))
+     ((not (stringp pel-package-user-dir-original))
       (pel-push-fmt
           problems
           "`pel-package-user-dir-original' has invalid value %S; expected a directory name string."
         pel-package-user-dir-original))
      ;;
-     ((and (boundp 'pel-package-user-dir-original)
-           (not (file-symlink-p pel-package-user-dir-original))
+     ((and (not (file-symlink-p pel-package-user-dir-original))
            (pel-same-fname-p
             pel-package-user-dir-original
             (pel-elpa-name (pel-sibling-dirpath

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-26 08:09:08 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-26 09:35:48 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -183,24 +183,34 @@ Return nil if all is OK."
     ;; The check below works in all modes including graphics+quickstart
     ;; because PEL early-init captures the value of `package-user-dir'
     ;; in `pel-package-user-dir-original'.
-    (if (boundp 'pel-package-user-dir-original)
-        (when (and (not (file-symlink-p pel-package-user-dir-original))
-                   (pel-same-fname-p
-                    pel-package-user-dir-original
-                    (pel-elpa-name (pel-sibling-dirpath
-                                    pel-package-user-dir-original
-                                    "elpa-complete")
-                                   (display-graphic-p))))
-          (pel-push-fmt
-           problems
-           "Incompatible elpa directory : %s.
-   It clashes with PEL's logic to flip between -complete and -reduced."
-           pel-package-user-dir-original))
+    (cond
+     ;;
+     ((not (boundp 'pel-package-user-dir-original))
       (pel-push-fmt
-       problems
-       "The init.el file is incompatible with PEL startup management:
+          problems
+          "The init.el or early-init.el file is incompatible with PEL startup management:
  - `pel-package-user-dir-original' is not bound.
-   It should be set in init.el to remember `package-user-dir'."))
+   It should be set to remember `package-user-dir'."))
+     ;;
+     ((not (stringp pel-package-user-dir-original))
+      (pel-push-fmt
+          problems
+          "`pel-package-user-dir-original' has invalid value %S; expected a directory name string."
+        pel-package-user-dir-original))
+     ;;
+     ((and (not (file-symlink-p pel-package-user-dir-original))
+           (pel-same-fname-p
+            pel-package-user-dir-original
+            (pel-elpa-name (pel-sibling-dirpath
+                            pel-package-user-dir-original
+                            "elpa-complete")
+                           (display-graphic-p))))
+       (pel-push-fmt
+           problems
+           "Incompatible elpa directory identified by pel-package-user-dir-original : %s.
+   This is not a symlink.
+   It clashes with PEL's logic to flip between -complete and -reduced."
+         pel-package-user-dir-original)))
     ;;
     (nreverse problems)))
 

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-26 13:39:28 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-26 13:50:57 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -80,8 +80,8 @@
 
 (require 'subr-x)              ; use: `string-join'
 
-(defvar pel-package-user-dir-original) ; Prevent warning only . Defined in
-                                       ; early-init (preferred) or init.el
+(defvar pel-package-user-dir-original) ; Prevent warning only.  Defined in
+                                       ; early-init (preferred) or init.el.
 
 
 ;;; --------------------------------------------------------------------------

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-26 09:35:48 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-26 10:00:27 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -192,13 +192,15 @@ Return nil if all is OK."
  - `pel-package-user-dir-original' is not bound.
    It should be set to remember `package-user-dir'."))
      ;;
-     ((not (stringp pel-package-user-dir-original))
+     ((and (boundp 'pel-package-user-dir-original)
+           (not (stringp pel-package-user-dir-original)))
       (pel-push-fmt
           problems
           "`pel-package-user-dir-original' has invalid value %S; expected a directory name string."
         pel-package-user-dir-original))
      ;;
-     ((and (not (file-symlink-p pel-package-user-dir-original))
+     ((and (boundp 'pel-package-user-dir-original)
+           (not (file-symlink-p pel-package-user-dir-original))
            (pel-same-fname-p
             pel-package-user-dir-original
             (pel-elpa-name (pel-sibling-dirpath

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-25 17:31:55 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-26 06:47:28 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -131,70 +131,76 @@ Return nil if all is OK."
     (if (boundp 'pel-init-file-version)
         (unless (string= (pel-as-string pel-init-file-version)
                          pel--expected-init-file-version)
-          (pel-push-fmt problems
-              "Invalid pel-init-file-version: %s instead of expected %s
+          (pel-push-fmt
+           problems
+           "Invalid pel-init-file-version: %s instead of expected %s
    Please update your init.el file.
    Use the pel/example/init/init.el as template."
-            pel-init-file-version pel--expected-init-file-version))
+           pel-init-file-version pel--expected-init-file-version))
       ;; `pel-init-file-version' is not bound at all: the init.el file does
       ;; not define it, so it was not prepared from the PEL template
       ;; or is using an old one.
-      (pel-push-fmt problems
-          "Invalid init.el file (%s): not ready for PEL startup management.
+      (pel-push-fmt
+       problems
+       "Invalid init.el file (%s): not ready for PEL startup management.
    It must define `pel-init-file-version' set to \"%s\".
    Use the pel/example/init/init.el as template."
-        user-init-file pel--expected-init-file-version))
+       user-init-file pel--expected-init-file-version))
     ;;
     (when pel-emacs-27-or-later-p
       (if (file-exists-p (locate-user-emacs-file "early-init.el"))
           (if (boundp 'pel-early-init-file-version)
               (unless (string= (pel-as-string pel-early-init-file-version)
                                pel--expected-early-init-file-version)
-                (pel-push-fmt problems
-                    "Invalid pel-early-init-file-version: %s instead of expected %s
+                (pel-push-fmt
+                 problems
+                 "Invalid pel-early-init-file-version: %s instead of expected %s
    Please update your early-init.el file.
    Use the pel/example/init/early-init.el as template."
-                  pel-early-init-file-version
-                  pel--expected-early-init-file-version))
+                 pel-early-init-file-version
+                 pel--expected-early-init-file-version))
             ;; `pel-early-init-file-version' is not bound at all: the
             ;; early-init.el file was not prepared from the PEL template
             ;; or is using an old one.
-            (pel-push-fmt problems
-                "Invalid early-init.el file (%searly-init.el): not ready for PEL startup management.
+            (pel-push-fmt
+             problems
+             "Invalid early-init.el file (%searly-init.el): not ready for PEL startup management.
    It must define `pel-early-init-file-version' set to \"%s\".
    Use the pel/example/init/early-init.el as template."
-              (file-name-parent-directory user-init-file)
-              pel--expected-early-init-file-version))
+             (file-name-parent-directory user-init-file)
+             pel--expected-early-init-file-version))
 
         (when early-init-must-exist
-          (pel-push-fmt problems
-              "This feature requires a PEL compatible early-init.el file
+          (pel-push-fmt
+           problems
+           "This feature requires a PEL compatible early-init.el file
    (with `pel-early-init-file-version' set to \"%s\")
    inside %s and that is missing.  Create one, using
    pel/example/init/early-init.el as template."
-            pel--expected-early-init-file-version
-            (file-name-parent-directory user-init-file)))))
+           pel--expected-early-init-file-version
+           (file-name-parent-directory user-init-file)))))
     ;;
-    ;; The next check cannot be performed when quickstart is used because in
-    ;; that case I cannot find a way to get the original value of
-    ;; package-user-dir inside the early-init.el file.  TODO.
-    (unless (bound-and-true-p package-quickstart)
-      (if (boundp 'pel-package-user-dir-original)
-          (when (and (not (file-symlink-p pel-package-user-dir-original))
-                     (pel-same-fname-p
-                      pel-package-user-dir-original
-                      (pel-elpa-name (pel-sibling-dirpath
-                                      pel-package-user-dir-original
-                                      "elpa-complete")
-                                     (display-graphic-p))))
-            (pel-push-fmt problems
-                "Incompatible elpa directory : %s.
+    ;; The check below works in all modes including graphics+quickstart
+    ;; because PEL early-init captures the value of `package-user-dir'
+    ;; in `pel-package-user-dir-original'.
+    (if (boundp 'pel-package-user-dir-original)
+        (when (and (not (file-symlink-p pel-package-user-dir-original))
+                   (pel-same-fname-p
+                    pel-package-user-dir-original
+                    (pel-elpa-name (pel-sibling-dirpath
+                                    pel-package-user-dir-original
+                                    "elpa-complete")
+                                   (display-graphic-p))))
+          (pel-push-fmt
+           problems
+           "Incompatible elpa directory : %s.
    It clashes with PEL's logic to flip between -complete and -reduced."
-              pel-package-user-dir-original))
-        (pel-push-fmt problems
-            "The init.el file is incompatible with PEL startup management:
+           pel-package-user-dir-original))
+      (pel-push-fmt
+       problems
+       "The init.el file is incompatible with PEL startup management:
  - `pel-package-user-dir-original' is not bound.
-   It should be set in init.el to remember `package-user-dir'.")))
+   It should be set in init.el to remember `package-user-dir'."))
     ;;
     (nreverse problems)))
 

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-26 06:47:28 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-26 08:09:08 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -113,7 +113,7 @@ In the current code this is only done by `pel--setup-dual-environment'")
 (defconst pel--expected-init-file-version "0.3.1"
   "Must match what is in the example/init/init.el.")
 
-(defconst pel--expected-early-init-file-version "0.4"
+(defconst pel--expected-early-init-file-version "0.5"
   "Must match what is in the example/init/early-init.el.")
 
 ;; --

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-26 12:17:06 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-26 13:39:28 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -80,7 +80,10 @@
 
 (require 'subr-x)              ; use: `string-join'
 
-(defvar pel-package-user-dir-original) ; Prevent warning. Defined in init or early-init
+(defvar pel-package-user-dir-original) ; Prevent warning only . Defined in
+                                       ; early-init (preferred) or init.el
+
+
 ;;; --------------------------------------------------------------------------
 ;;; Code:
 ;;

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-26 10:30:23 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-26 12:17:06 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -133,20 +133,20 @@ Return nil if all is OK."
         (unless (string= (pel-as-string pel-init-file-version)
                          pel--expected-init-file-version)
           (pel-push-fmt
-           problems
-           "Invalid pel-init-file-version: %s instead of expected %s
+              problems
+              "Invalid pel-init-file-version: %s instead of expected %s
    Please update your init.el file.
    Use the pel/example/init/init.el as template."
-           pel-init-file-version pel--expected-init-file-version))
+            pel-init-file-version pel--expected-init-file-version))
       ;; `pel-init-file-version' is not bound at all: the init.el file does
       ;; not define it, so it was not prepared from the PEL template
       ;; or is using an old one.
       (pel-push-fmt
-       problems
-       "Invalid init.el file (%s): not ready for PEL startup management.
+          problems
+          "Invalid init.el file (%s): not ready for PEL startup management.
    It must define `pel-init-file-version' set to \"%s\".
    Use the pel/example/init/init.el as template."
-       user-init-file pel--expected-init-file-version))
+        user-init-file pel--expected-init-file-version))
     ;;
     (when pel-emacs-27-or-later-p
       (if (file-exists-p (locate-user-emacs-file "early-init.el"))
@@ -154,32 +154,32 @@ Return nil if all is OK."
               (unless (string= (pel-as-string pel-early-init-file-version)
                                pel--expected-early-init-file-version)
                 (pel-push-fmt
-                 problems
-                 "Invalid pel-early-init-file-version: %s instead of expected %s
+                    problems
+                    "Invalid pel-early-init-file-version: %s instead of expected %s
    Please update your early-init.el file.
    Use the pel/example/init/early-init.el as template."
-                 pel-early-init-file-version
-                 pel--expected-early-init-file-version))
+                  pel-early-init-file-version
+                  pel--expected-early-init-file-version))
             ;; `pel-early-init-file-version' is not bound at all: the
             ;; early-init.el file was not prepared from the PEL template
             ;; or is using an old one.
             (pel-push-fmt
-             problems
-             "Invalid early-init.el file (%searly-init.el): not ready for PEL startup management.
+                problems
+                "Invalid early-init.el file (%searly-init.el): not ready for PEL startup management.
    It must define `pel-early-init-file-version' set to \"%s\".
    Use the pel/example/init/early-init.el as template."
-             (file-name-parent-directory user-init-file)
-             pel--expected-early-init-file-version))
+              (file-name-parent-directory user-init-file)
+              pel--expected-early-init-file-version))
 
         (when early-init-must-exist
           (pel-push-fmt
-           problems
-           "This feature requires a PEL compatible early-init.el file
+              problems
+              "This feature requires a PEL compatible early-init.el file
    (with `pel-early-init-file-version' set to \"%s\")
    inside %s and that is missing.  Create one, using
    pel/example/init/early-init.el as template."
-           pel--expected-early-init-file-version
-           (file-name-parent-directory user-init-file)))))
+            pel--expected-early-init-file-version
+            (file-name-parent-directory user-init-file)))))
     ;;
     ;; The check below works in all modes including graphics+quickstart
     ;; because PEL early-init captures the value of `package-user-dir'
@@ -206,12 +206,12 @@ Return nil if all is OK."
                             pel-package-user-dir-original
                             "elpa-complete")
                            (display-graphic-p))))
-       (pel-push-fmt
-           problems
-           "Incompatible elpa directory identified by pel-package-user-dir-original : %s.
+      (pel-push-fmt
+          problems
+          "Incompatible elpa directory identified by pel-package-user-dir-original : %s.
    This is not a symlink.
    It clashes with PEL's logic to flip between -complete and -reduced."
-         pel-package-user-dir-original)))
+        pel-package-user-dir-original)))
     ;;
     (nreverse problems)))
 

--- a/pel-setup-base.el
+++ b/pel-setup-base.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, August 31 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-26 10:00:27 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-26 10:15:58 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -80,6 +80,7 @@
 
 (require 'subr-x)              ; use: `string-join'
 
+(defvar pel-package-user-dir-original) ; Prevent warning. Defined in init or early-init
 ;;; --------------------------------------------------------------------------
 ;;; Code:
 ;;

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-26 14:14:59 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-26 14:36:52 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -1192,15 +1192,10 @@ Return a list of performed action descriptions in reverse order."
                                             elpa-dp "elpa-complete")
                                            for-graphics))
              (actions nil))
-        (unless (or (file-symlink-p elpa-dp)
-                    (bound-and-true-p package-quickstart))
+        (unless (file-symlink-p elpa-dp)
           ;; the main elpa is a directory, not a symbolic link
           ;; make sure it does not already use the elpa-complete name;
-          ;; Complain if it does.  However only perform this check when
-          ;; not using package quickstart because in package quickstart I have
-          ;; not found a way to identify the original package-user-dir which
-          ;; identifies the symlink when fast start is used and then elpa-dp
-          ;; ends up having the value of the symlink target.  TODO.
+          ;; Complain if it does.
           (when (pel-same-fname-p elpa-dp elpa-dp-cmplt)
             (user-error "Invalid elpa directory in %s:
  The elpa directory name (%s) clash with PEL startup management strategy.
@@ -1275,47 +1270,43 @@ The directory (or symlink to the directory) that should hold
           (pel-elpa-name custom-file for-graphics)
           original-elpa-dirpath)
       ;;
-      ;; elpa exists, check its validity, but only do that
-      ;;  when package quickstart is disabled as PEL is not yet capable of
-      ;;  getting to the original package-user-dir when package quickstart is
-      ;;  used. TODO.
-      (unless (bound-and-true-p package-quickstart)
-        (if elpa-symlink
-            (progn
-              (unless (pel-symlink-points-to-p elpa-dirname
-                                               elpa-complete-dirpath)
-                (pel-push-fmt problems "The elpa symlink target is invalid.
+      ;; elpa exists, check its validity.
+      (if elpa-symlink
+          (progn
+            (unless (pel-symlink-points-to-p elpa-dirname
+                                             elpa-complete-dirpath)
+              (pel-push-fmt problems "The elpa symlink target is invalid.
    - Current symlink target : %s
    - Expected symlink target: %s"
-                  elpa-symlink
-                  elpa-complete-dirpath))
-              ;;
-              (unless (file-name-absolute-p elpa-symlink)
-                (pel-push-fmt problems
-                    "The %s symlink target is not an absolute path:
+                elpa-symlink
+                elpa-complete-dirpath))
+            ;;
+            (unless (file-name-absolute-p elpa-symlink)
+              (pel-push-fmt problems
+                  "The %s symlink target is not an absolute path:
    - Current symlink target : %s
    - Expected symlink target: %s
  Attempting a repair."
-                  elpa-dirpath
-                  elpa-symlink
-                  elpa-complete-dirpath)
-                ;; try to repair it
-                (pel-point-symlink-to elpa-dirname elpa-complete-dirpath)
-                (setq elpa-symlink (file-symlink-p elpa-dirname)))
-              ;;
-              (unless (directory-name-p elpa-symlink)
-                (pel-push-fmt problems
-                    "\
+                elpa-dirpath
+                elpa-symlink
+                elpa-complete-dirpath)
+              ;; try to repair it
+              (pel-point-symlink-to elpa-dirname elpa-complete-dirpath)
+              (setq elpa-symlink (file-symlink-p elpa-dirname)))
+            ;;
+            (unless (directory-name-p elpa-symlink)
+              (pel-push-fmt problems
+                  "\
 The elpa symlink target format does not use a directory name format:
    - Current symlink target : %s
    - Expected symlink target: %s
  Attempting a repair."
-                  elpa-symlink
-                  elpa-complete-dirpath)
-                ;; try to repair it.
-                (pel-point-symlink-to elpa-dirname elpa-complete-dirpath)))
-          (pel-push-fmt problems "The elpa is not a symlink  : %s"
-            elpa-dirname))))
+                elpa-symlink
+                elpa-complete-dirpath)
+              ;; try to repair it.
+              (pel-point-symlink-to elpa-dirname elpa-complete-dirpath)))
+        (pel-push-fmt problems "The elpa is not a symlink  : %s"
+          elpa-dirname)))
     (nreverse problems)))
 
 (defun pel--validate-elpa-symlink (elpa-dirpath for-graphics )

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-26 14:36:52 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-26 14:50:27 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -1216,10 +1216,11 @@ Return a list of performed action descriptions in reverse order."
               "Created %s symlink that points to %s"
             elpa-dp elpa-dp-cmplt))
         actions)
-    (user-error "Invalid init.el file detected:
+    (user-error "Invalid init.el or early-init.el file detected:
   The `pel-package-user-dir-original' symbol is unknown.
   PEL cannot safely manage Emacs startup mode.
-  Please update your init.el file; use pel/example/init/init.el template!")))
+  Please update your init.el (and early-init.el if present);
+  use pel/example/init/ templates!")))
 
 (defun pel--elpa-symlink-problems (elpa-dirpath for-graphics)
   "Check validity of ELPA_DIRPATH used FOR-GRAPHICS.

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-24 22:46:59 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-26 06:59:13 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -1779,21 +1779,8 @@ Failed fast startup setup for %s after step %d: %s
     (pel--require-process-detection))
 
   ;; When all conditions are OK, check further
-  (cond
-   ;;
-   ((eq (pel-startup-mode) 'fast)
-    (user-error "PEL/Emacs is already setup for fast startup!"))
-   ;;
-   ((and (bound-and-true-p package-quickstart)
-         (display-graphic-p))
-    (user-error "PEL currently is not able to switch to fast startup mode when
-  package quickstart is used and Emacs is running in graphic mode.
-  Use Emacs running in terminal mode or turn package quickstart off
-  (with M-x pel-setup-no-quickstart) to execute this command.
-  Once the switch is completed, PEL can run in fast startup mode with package
-  startup active in graphic mode. Sorry for the inconvenience"))
-   ;;
-   (t
+  (if (eq (pel-startup-mode) 'fast)
+       (user-error "PEL/Emacs is already setup for fast startup!")
     (when (y-or-n-p (pel-prompt-with-quickstart-state
                      "Change to fast startup mode"
                      :show-requested-quickstart))
@@ -1807,7 +1794,7 @@ Failed fast startup setup for %s after step %d: %s
         (pel--setup-fast t))
       ;; inform user, possibly after a deprecated warning
       (run-with-idle-timer 1 nil (function pel--setup-fast-message))
-      (setq pel-fast-startup-setup-changed t)))))
+      (setq pel-fast-startup-setup-changed t))))
 
 ;; --
 (defun pel--delete-file-dir (dest)
@@ -2003,21 +1990,8 @@ Correct the problem manually before retrying M-x pel-setup-normal."))
   "Restore normal PEL/Emacs operation mode."
   (interactive)
   (pel-setup-validate-init-files)
-  (cond
-   ((eq (pel-startup-mode) 'normal)
-    (user-error "PEL/Emacs is already using the normal setup!"))
-   ;; [:todo 2026-05-23, by Pierre Rouleau: In order to lift this restriction
-   ;;                    the `pel--setup-init-file-problems' issue identified
-   ;;                    by another TODO must be resolved.  ]
-   ((and (bound-and-true-p package-quickstart)
-         (display-graphic-p))
-    (user-error "\
-PEL currently is not able to restore from fast startup mode when
-  package quickstart is used and Emacs is running in graphic mode.
-  Use Emacs running in terminal mode or turn package quickstart off
-  (with M-x pel-setup-no-quickstart) to execute this command.
-  Sorry for the inconvenience"))
-   (t
+  (if (eq (pel-startup-mode) 'normal)
+      (user-error "PEL/Emacs is already using the normal setup!")
     (when (y-or-n-p (pel-prompt-with-quickstart-state
                      "Restore normal startup mode"
                      :show-requested-quickstart))
@@ -2034,7 +2008,7 @@ PEL currently is not able to restore from fast startup mode when
                (pel-string-when
                 pel-detected-dual-environment-in-init-p
                 "\n Affects Emacs running in terminal and graphics mode!"))
-      (setq pel-fast-startup-setup-changed t)))))
+      (setq pel-fast-startup-setup-changed t))))
 
 ;;; --------------------------------------------------------------------------
 (provide 'pel-setup)

--- a/pel-setup.el
+++ b/pel-setup.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Thursday, July  8 2021.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-05-26 06:59:13 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-05-26 14:14:59 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the PEL package.
 ;; This file is not part of GNU Emacs.
@@ -1172,8 +1172,8 @@ If it is nil, do it for the default directories used when dual-environment is
 not used or when used with terminal based Emacs.
 
 The elpa directory is identified by the `pel-package-user-dir-original'
-variable set by init.el before its renaming of the `package-user-dir' to
-control the content of the `load-path'.
+variable captured by `early-init.el' at load time (preferred), or by
+`init.el' as a fallback when no `early-init.el' is present.
 
 - If this already is a symlink, then do nothing.
 - Otherwise it identifies a directory and proceed:

--- a/pel_keys.el
+++ b/pel_keys.el
@@ -11485,6 +11485,13 @@ This call simulates a F7 prefix key unless DONT-SIMULATE is non-nil."
       (pel-byte-compile-if-needed el-filename))))
 
 ;; ---------------------------------------------------------------------------
+;;* Optional Loading of User Extra Startup Code
+;;  ===========================================
+(when pel-user-extra-code-feature
+  ;; load user's extra code; prevent errors from affecting startup.
+  (require pel-user-extra-code-feature nil 'noerror))
+
+;; ---------------------------------------------------------------------------
 (provide 'pel_keys)
 
 ;;; pel_keys.el ends here

--- a/pel_keys.el
+++ b/pel_keys.el
@@ -11488,8 +11488,22 @@ This call simulates a F7 prefix key unless DONT-SIMULATE is non-nil."
 ;;* Optional Loading of User Extra Startup Code
 ;;  ===========================================
 (when pel-user-extra-code-feature
-  ;; load user's extra code; prevent errors from affecting startup.
-  (require pel-user-extra-code-feature nil 'noerror))
+  (if (symbolp pel-user-extra-code-feature)
+      ;; load user's extra code; prevent errors from affecting startup.
+      (condition-case err
+          (require pel-user-extra-code-feature nil 'noerror)
+        (error
+         (warn "ERROR loading your extra initialization file specified by: %s
+The detected error is: %s"
+               pel-user-extra-code-feature
+               (error-message-string err))))
+    ;; pel-user-extra-code-feature is not a symbol; cannot load.
+    (display-warning
+     'pel-user-extra-init
+     (format "The `pel-user-extra-code-feature' user-option must be a symbol
+but its value is %S.  Please update your customization."
+             pel-user-extra-code-feature)
+     :warning)))
 
 ;; ---------------------------------------------------------------------------
 (provide 'pel_keys)

--- a/pel_keys.el
+++ b/pel_keys.el
@@ -11493,10 +11493,12 @@ This call simulates a F7 prefix key unless DONT-SIMULATE is non-nil."
       (condition-case err
           (require pel-user-extra-code-feature nil 'noerror)
         (error
-         (warn "ERROR loading your extra initialization file specified by: %s
-The detected error is: %s"
-               pel-user-extra-code-feature
-               (error-message-string err))))
+         (display-warning
+          'pel-user-extra-init
+          (format "Error loading `%s': %s\nCheck the file providing this feature."
+                  pel-user-extra-code-feature
+                  (error-message-string err))
+          :warning)))
     ;; pel-user-extra-code-feature is not a symbol; cannot load.
     (display-warning
      'pel-user-extra-init


### PR DESCRIPTION
* Modified early-init.el and PEL startup switch logic to allow switching startup mode with a GUI Emacs using package quickstart.

* Because the early-init.el file *must* be updated in the users environment with the new PEL logic change, I also added logic in the Make-driven build to check the validity of the user's early-init and init.el file.  The check is done at the very beginning of the build or clean steps to prevent the use of new PEL logic if this depends on new versions of the early-init.el or init.el (and it is the case for this commit).

  - The check logic is implemented in Emacs Lisp, allowing to run it on any OS that supports Emacs.  The code is located inside the new file build/check-init-versions-for-pel.el.  That file is not byte/native compiled and does not need any parts of PEL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build now validates user init files for compatible versions before building; CI skips user-only checks.
  * Option to load user-provided extra startup code after core initialization.
  * User init files are byte-compiled post-build when present.

* **Chores**
  * Pre-build validation and post-build compilation integrated into build flow; build stamps tracked and ignored by VCS.
  * Clean removes stamp files; test/compile targets depend on validation.

* **Behavioral Changes**
  * Example early-init version bumped; original package directory preserved; startup-mode guards simplified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->