### PR TITLE
Add ability to build even when user init have warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-2026 by Pierre Rouleau
 
 # Author: Pierre Rouleau <prouleau001@gmail.com>
-# Last Modified Time-stamp: <2026-05-26 21:25:50 EDT, updated by Pierre Rouleau>
+# Last Modified Time-stamp: <2026-05-26 21:44:48 EDT, updated by Pierre Rouleau>
 # Keywords: packaging, build-control
 
 # This file is part of the PEL package
@@ -676,7 +676,7 @@ first-build: build/.check-init-stamp $(ELC_FILES)
 compile-only: build/.check-init-stamp $(ELC_FILES) pel_keys.elc pel.elc \
               build/.compile-user-init-stamp
 
-compile-only-pel: $(ELC_FILES) pel_keys.elc pel.elc
+compile-only-pel: build/.check-init-stamp $(ELC_FILES) pel_keys.elc pel.elc
 # -----------------------------------------------------------------------------
 # Self-descriptive rule: make help prints the info.
 
@@ -703,7 +703,8 @@ help:
 	@printf " * make all           - Compile all files and run tests as soon as possible.\n"
 	@printf " * make compile-only  - Compile all PEL Emacs Lisp and user init files. Do not run tests.\n"
 	@printf " * make compile-only-pel  - Compile all PEL Emacs Lisp. Do not run tests.\n"
-	@printf "                            Use this if you have problem compiling init.el and earluy-init.el\n"
+	@printf "                            Checks the version of init.el and early-init.el but does not compile them.\n"
+	@printf "                            Use this if you have problem compiling init.el and early-init.el\n"
 	@printf "                            without warnings.\n"
 	@printf " * make pel           - Compile all files except pel.el. Do not run tests.\n"
 	@printf " * make first-build   - First build done on a virgin system:\n"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-2026 by Pierre Rouleau
 
 # Author: Pierre Rouleau <prouleau001@gmail.com>
-# Last Modified Time-stamp: <2026-05-26 14:38:29 EDT, updated by Pierre Rouleau>
+# Last Modified Time-stamp: <2026-05-26 21:25:50 EDT, updated by Pierre Rouleau>
 # Keywords: packaging, build-control
 
 # This file is part of the PEL package
@@ -652,7 +652,7 @@ endif
 # -----------------------------------------------------------------------------
 # First rule, allows 'make' command to build everything that needs updating
 
-.PHONY: all compile-only first-build pel-top
+.PHONY: all compile-only compile-only-pel first-build pel-top
 
 # Target all (the default target):
 # - First build the .elc files to check for errors, running tests
@@ -676,6 +676,7 @@ first-build: build/.check-init-stamp $(ELC_FILES)
 compile-only: build/.check-init-stamp $(ELC_FILES) pel_keys.elc pel.elc \
               build/.compile-user-init-stamp
 
+compile-only-pel: $(ELC_FILES) pel_keys.elc pel.elc
 # -----------------------------------------------------------------------------
 # Self-descriptive rule: make help prints the info.
 
@@ -701,6 +702,9 @@ help:
 	@printf " * make               - Same as 'make all': build everything as needed.\n"
 	@printf " * make all           - Compile all files and run tests as soon as possible.\n"
 	@printf " * make compile-only  - Compile all PEL Emacs Lisp and user init files. Do not run tests.\n"
+	@printf " * make compile-only-pel  - Compile all PEL Emacs Lisp. Do not run tests.\n"
+	@printf "                            Use this if you have problem compiling init.el and earluy-init.el\n"
+	@printf "                            without warnings.\n"
 	@printf " * make pel           - Compile all files except pel.el. Do not run tests.\n"
 	@printf " * make first-build   - First build done on a virgin system:\n"
 	@printf "                         compile all files except pel_keys.el and pel.el.\n"

--- a/bin/build-pel
+++ b/bin/build-pel
@@ -4,7 +4,7 @@
 # Purpose   : Build PEL quickly from scratch then run all tests and display stats.
 # Created   : Monday, May 11 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-26 21:31:21 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-26 22:07:05 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -37,7 +37,7 @@ make check-init && \
     make clean && \
     make -j compile-only-pel && \
     make lint && \
-    make && \
+    make test && \
     make compile-init && \
     make stats
 

--- a/bin/build-pel
+++ b/bin/build-pel
@@ -4,7 +4,7 @@
 # Purpose   : Build PEL quickly from scratch then run all tests and display stats.
 # Created   : Monday, May 11 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-26 14:41:31 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-26 21:31:21 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -15,7 +15,8 @@
 # - build PEL Emacs Lisp code quickly (using concurrent Make build),
 # - check if there are any issues in the key prefix logic between pel_keys.el and pel--keys-macros.el,
 # - run all unit tests
-# - and complete by loading everything in an Emacs session then print PEL stats.
+# - byte compile user init and, when present, the early-init.el
+# - Load everything in an Emacs session then print PEL stats.
 
 # ----------------------------------------------------------------------------
 # Dependencies
@@ -30,6 +31,14 @@
 
 # Check user init and early-init right at the beginning to prevent cleaning
 # if the user's file should be updated.
+# Build user init/early-init before making stats.
 #
-make check-init && make clean && make -j compile-only && make lint && make && make stats
+make check-init && \
+    make clean && \
+    make -j compile-only-pel && \
+    make lint && \
+    make && \
+    make compile-init && \
+    make stats
+
 # ----------------------------------------------------------------------------

--- a/example/init/early-init.el
+++ b/example/init/early-init.el
@@ -231,6 +231,9 @@ This value is used by `pel-force-graphic-specific-custom-file-p'.")
 ;; makes the init.el assignment a no-op when this early-init code has
 ;; already saved the value.
 
+;; Warning Prevention
+(defvar package-user-dir)             ; prevent byte-compiler warning
+
 (defvar pel-package-user-dir-original
   (if (boundp 'package-user-dir)
       package-user-dir
@@ -308,6 +311,7 @@ For debugging and to quiet byte-compiler warning.")
   ;;     `package-activate-all'
   ;;
   (defvar package-quickstart)           ; prevent byte-compiler warning
+  (defvar package-quickstart-file)      ; prevent byte-compiler warning
   (when pel-early-init-support-package-quickstart-p
     (setq package-quickstart t)
 

--- a/example/init/init.el
+++ b/example/init/init.el
@@ -114,7 +114,11 @@ in dual environment mode).  Having access to the original value lets
 `pel-setup-fast' and `pel-setup-normal' correctly establish or remove
 the PEL directory structure on first invocation.")
 
+;; ---------------------------------------------------------------------------
+;; Warning Prevention
+(defvar package-user-dir)             ; prevent byte-compiler warning
 
+;; ---------------------------------------------------------------------------
 ;; Section 1 : Utility function definition
 ;; =======================================
 ;;


### PR DESCRIPTION
* Add `make compile-only-pel` and change the way `build-pel` builds to ensure that it's possible to setup PEL even when there is an issue with the user's init.el and early-init.el that do not byte-compile without warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new compilation-only build target for PEL sources and documented it in build help.
  * Updated the build pipeline to explicitly rebuild initialization before generating stats.

* **Bug Fixes**
  * Added explicit variable declarations in init/early-init sequences to prevent byte‑compiler warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->